### PR TITLE
fix: accept ### Sprint headings in SPRINT_HEADING_RE (#10)

### DIFF
--- a/codd/implementer.py
+++ b/codd/implementer.py
@@ -60,7 +60,7 @@ def count_sprints(project_root: Path) -> int:
             total = i
     return total
 SPRINT_HEADING_RE = re.compile(
-    r"^####\s+Sprint\s+(?P<number>\d+)(?:（(?P<window>[^）]+)）)?(?:\s*:\s*(?P<title>.+))?\s*$",
+    r"^#{3,4}\s+Sprint\s+(?P<number>\d+)(?:（(?P<window>[^）]+)）)?(?:\s*[:\u2014\u2013\-]\s*(?P<title>.+))?\s*$",
     re.MULTILINE,
 )
 SECTION_HEADING_RE = re.compile(r"^##\s+\d+\.\s+(?P<title>.+?)\s*$", re.MULTILINE)

--- a/tests/test_implement.py
+++ b/tests/test_implement.py
@@ -348,3 +348,89 @@ def test_get_task_slugs_by_sprint_no_plan(tmp_path):
 
     result = get_task_slugs_by_sprint(project)
     assert result == {}
+
+
+# Regression tests for issue #10: SPRINT_HEADING_RE should accept both ### and ####
+# as well as various separators (colon, em dash, en dash, hyphen) between the sprint
+# number and the title. AI-generated plans tend to use `### Sprint N — Title` while
+# the original regex only matched `#### Sprint N: Title`.
+
+
+def _build_plan_with_sprint_heading(tmp_path: Path, heading: str) -> Path:
+    """Create a minimal project with a single sprint heading for regex testing."""
+    project = tmp_path / "project"
+    project.mkdir()
+    codd_dir = project / "codd"
+    codd_dir.mkdir()
+    (codd_dir / "codd.yaml").write_text(
+        "project:\n  name: demo\n  language: typescript\n"
+    )
+    plan_body = (
+        "# Implementation Plan\n\n"
+        "## 1. Overview\n\n"
+        "Foundation work.\n\n"
+        f"{heading}\n\n"
+        "| # | 作業項目 | 対応モジュール | 成果物 |\n"
+        "|---|---|---|---|\n"
+        "| 1-1 | Setup | `lib/setup.ts` | Initial scaffold |\n"
+    )
+    _write_doc(
+        project,
+        "docs/plan/implementation_plan.md",
+        node_id="plan:implementation-plan",
+        doc_type="plan",
+        body=plan_body,
+    )
+    return project
+
+
+@pytest.mark.parametrize(
+    "heading",
+    [
+        "#### Sprint 1: Foundation",
+        "### Sprint 1: Foundation",
+        "#### Sprint 1 — Foundation",
+        "### Sprint 1 — Foundation",
+        "### Sprint 1 – Foundation",
+        "### Sprint 1 - Foundation",
+        "#### Sprint 1（4月1日〜4月14日）: Foundation",
+        "### Sprint 1（4月1日〜4月14日）— Foundation",
+    ],
+)
+def test_count_sprints_accepts_h3_and_h4_with_various_separators(tmp_path, heading):
+    """Issue #10: Sprint headings should be recognized at ### or #### with any
+    of the common separators (colon, em dash, en dash, hyphen)."""
+    project = _build_plan_with_sprint_heading(tmp_path, heading)
+    assert implementer_module.count_sprints(project) == 1
+
+
+def test_count_sprints_parses_multiple_h3_sprints(tmp_path):
+    """Issue #10: Multiple ### Sprint headings in a single plan are all counted."""
+    project = tmp_path / "project"
+    project.mkdir()
+    codd_dir = project / "codd"
+    codd_dir.mkdir()
+    (codd_dir / "codd.yaml").write_text(
+        "project:\n  name: demo\n  language: typescript\n"
+    )
+    plan_body = (
+        "# Implementation Plan\n\n"
+        "## 1. Overview\n\n"
+        "Multi-sprint plan.\n\n"
+        "### Sprint 1 — Foundation\n\n"
+        "| # | 作業項目 | 対応モジュール | 成果物 |\n"
+        "|---|---|---|---|\n"
+        "| 1-1 | Setup | `lib/setup.ts` | Initial scaffold |\n\n"
+        "### Sprint 2 — Core\n\n"
+        "| # | 作業項目 | 対応モジュール | 成果物 |\n"
+        "|---|---|---|---|\n"
+        "| 2-1 | Domain | `lib/domain.ts` | Domain types |\n"
+    )
+    _write_doc(
+        project,
+        "docs/plan/implementation_plan.md",
+        node_id="plan:implementation-plan",
+        doc_type="plan",
+        body=plan_body,
+    )
+    assert implementer_module.count_sprints(project) == 2


### PR DESCRIPTION
## Summary

Fixes part of #10: `codd plan --sprints` returns incorrect values when AI-generated plans use `###` Sprint headings instead of `####`.

## How I found this

I was trying out codd-dev on a new greenfield project (a small Obsidian-like markdown notes app) and ran the full pipeline (`codd init` → `plan --init` → `generate` → `validate` → `implement`). Everything worked beautifully up to `validate`, but `codd plan --sprints` returned `0` and `codd implement --sprint 1` failed with "implementation plan does not define sprint 1".

After digging into the generated `implementation_plan.md` and the implementer source, I realized the AI had used `### Sprint N` headings (following natural Markdown hierarchy) while `SPRINT_HEADING_RE` only matches `####`. Searching the issues, I found #10, which describes the exact same root cause — manifesting as `99` in their project and `0` in mine, both due to the same regex mismatch causing fallthrough.

## Changes

- **\`codd/implementer.py\`**: \`SPRINT_HEADING_RE\` now matches both \`###\` and \`####\`, plus em-dash / en-dash / hyphen separators in addition to colon.
- **\`tests/test_implement.py\`**: Added parametrized regression tests covering h3/h4 headings and all separator variations (including Japanese full-width parentheses for the window group).

## Why this scope

Issue #10 identifies multiple contributing factors (prompt gaps, validator gaps, regex mismatch). This PR focuses on **just the regex fix** because:

- **Backward compatible**: Existing \`####\` format keeps working.
- **Forward compatible**: AI-generated \`###\` now works out of the box — eliminates the \`count == 0\` and milestone-fallback-overcount (e.g., \`99\`) cases.
- **Easy to review**: Small, focused change with clear test coverage.

Broader improvements (plan-specific prompt rules in \`generator.py\`, validator warnings for wrong heading levels) can follow in separate PRs if the maintainers find them desirable.

## Test plan

- [x] All existing tests pass (\`uv run pytest tests/\` → 524 passed)
- [x] New regression tests cover \`### Sprint N\`, \`#### Sprint N\`, and em/en/hyphen/colon separators
- [x] Manually reproduced Issue #10 symptoms before the fix, confirmed resolved after

## Notes

First contribution to this project — thanks for building CoDD! Happy to iterate on style/approach if any adjustments are needed.