### PR TITLE
fix(windows): specify utf-8 encoding for file I/O

### DIFF
--- a/codd/cli.py
+++ b/codd/cli.py
@@ -143,7 +143,7 @@ def init(project_name: str, language: str, dest: str, requirements: str | None, 
     _render_template("gitignore.tmpl", codd_dir / ".gitignore", {})
 
     # Version file
-    (dest_path / ".codd_version").write_text("0.2.0\n")
+    (dest_path / ".codd_version").write_text("0.2.0\n", encoding="utf-8")
 
     # Import requirements if provided
     if requirements:
@@ -1071,13 +1071,13 @@ def _render_template(template_name: str, dest: Path, variables: dict):
     tmpl_path = TEMPLATES_DIR / template_name
     if not tmpl_path.exists():
         # Create empty file if template doesn't exist yet
-        dest.write_text(f"# TODO: template {template_name} not yet created\n")
+        dest.write_text(f"# TODO: template {template_name} not yet created\n", encoding="utf-8")
         return
 
-    content = tmpl_path.read_text()
+    content = tmpl_path.read_text(encoding="utf-8")
     for key, value in variables.items():
         content = content.replace(f"{{{{{key}}}}}", value)
-    dest.write_text(content)
+    dest.write_text(content, encoding="utf-8")
 
 
 def _import_requirements(project_root: Path, source: Path, project_name: str) -> Path:

--- a/codd/cli.py
+++ b/codd/cli.py
@@ -705,7 +705,7 @@ def repair_slice_cmd(path, files, issue, issue_file, language, source_dirs, top_
 
     issue_text = issue or ""
     if issue_file and not issue_text:
-        issue_text = Path(issue_file).read_text(errors="ignore")
+        issue_text = Path(issue_file).read_text(encoding="utf-8", errors="ignore")
 
     dirs = [d.strip() for d in source_dirs.split(",") if d.strip()] if source_dirs else None
 

--- a/codd/contracts.py
+++ b/codd/contracts.py
@@ -94,7 +94,7 @@ def build_interface_contracts(facts: ProjectFacts, project_root: Path) -> None:
         if init_files:
             init_path = project_root / init_files[0]
             try:
-                init_content = init_path.read_text(errors="ignore")
+                init_content = init_path.read_text(encoding="utf-8", errors="ignore")
             except Exception:
                 init_content = ""
             public = detect_init_exports(init_content)

--- a/codd/env_refs.py
+++ b/codd/env_refs.py
@@ -196,7 +196,7 @@ def build_env_refs(facts: "ProjectFacts", project_root: Path) -> None:
         for rel_file in getattr(mod, "files", []):
             full = project_root / rel_file
             try:
-                content = full.read_text(errors="ignore")
+                content = full.read_text(encoding="utf-8", errors="ignore")
             except Exception:
                 continue
             refs = detect_env_refs(content, rel_file)

--- a/codd/extract_ai.py
+++ b/codd/extract_ai.py
@@ -396,7 +396,7 @@ def _invoke_ai_command(ai_command: str, prompt: str) -> str:
             command,
             input=prompt,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             check=False,
         )
     except FileNotFoundError as exc:

--- a/codd/extractor.py
+++ b/codd/extractor.py
@@ -982,7 +982,7 @@ def run_extract(project_root: Path, language: str | None = None,
     if codd_dir is not None and (language is None or source_dirs is None):
         codd_yaml = codd_dir / "codd.yaml"
         if codd_yaml.exists():
-            config = yaml.safe_load(codd_yaml.read_text())
+            config = yaml.safe_load(codd_yaml.read_text(encoding="utf-8"))
             if language is None:
                 language = config.get("project", {}).get("language")
             if source_dirs is None:

--- a/codd/extractor.py
+++ b/codd/extractor.py
@@ -332,7 +332,7 @@ def _discover_modules(facts: ProjectFacts, project_root: Path, src_dir: Path,
 
             # Count lines
             try:
-                content = full.read_text(errors="ignore")
+                content = full.read_text(encoding="utf-8", errors="ignore")
                 lines = len(content.splitlines())
                 mod.line_count += lines
                 facts.total_lines += lines
@@ -377,7 +377,7 @@ def _discover_schemas(facts: ProjectFacts, project_root: Path, exclude_patterns:
                 continue
 
             try:
-                content = full.read_text(errors="ignore")
+                content = full.read_text(encoding="utf-8", errors="ignore")
             except Exception:
                 continue
 
@@ -606,7 +606,7 @@ def _map_tests_to_modules(facts: ProjectFacts, project_root: Path,
             full = Path(root) / fname
             rel = full.relative_to(project_root).as_posix()
             try:
-                content = full.read_text(errors="ignore")
+                content = full.read_text(encoding="utf-8", errors="ignore")
             except Exception:
                 content = ""
             test_info = test_extractor.extract_test_info(content, rel)
@@ -669,18 +669,18 @@ def _detect_patterns(facts: ProjectFacts, project_root: Path):
     pom_xml = project_root / "pom.xml"
 
     if pyproject.exists():
-        content = pyproject.read_text(errors="ignore")
+        content = pyproject.read_text(encoding="utf-8", errors="ignore")
         _detect_python_patterns(facts, content)
     elif setup_py.exists():
-        content = setup_py.read_text(errors="ignore")
+        content = setup_py.read_text(encoding="utf-8", errors="ignore")
         _detect_python_patterns(facts, content)
 
     if package_json.exists():
-        content = package_json.read_text(errors="ignore")
+        content = package_json.read_text(encoding="utf-8", errors="ignore")
         _detect_js_patterns(facts, content)
 
     if go_mod.exists():
-        content = go_mod.read_text(errors="ignore")
+        content = go_mod.read_text(encoding="utf-8", errors="ignore")
         _detect_go_patterns(facts, content)
 
     # Scan source files for framework-specific patterns
@@ -688,7 +688,7 @@ def _detect_patterns(facts: ProjectFacts, project_root: Path):
     for mod in facts.modules.values():
         for fpath in mod.files:
             try:
-                content = (project_root / fpath).read_text(errors="ignore")
+                content = (project_root / fpath).read_text(encoding="utf-8", errors="ignore")
             except Exception:
                 continue
             extractor.detect_code_patterns(mod, content)
@@ -918,7 +918,7 @@ def _extract_call_graphs(facts: ProjectFacts, project_root: Path,
         for rel_file in mod.files:
             full = project_root / rel_file
             try:
-                content = full.read_text(errors="ignore")
+                content = full.read_text(encoding="utf-8", errors="ignore")
             except Exception:
                 continue
             edges = extractor.extract_call_graph(content, rel_file, mod.symbols)

--- a/codd/fixer.py
+++ b/codd/fixer.py
@@ -389,7 +389,7 @@ def _detect_ci_failures(project_root: Path) -> list[FailureInfo]:
         result = subprocess.run(
             ["gh", "run", "list", "--limit", "1", "--json",
              "status,conclusion,databaseId,headBranch"],
-            capture_output=True, text=True, cwd=str(project_root),
+            capture_output=True, text=True, encoding="utf-8", cwd=str(project_root),
         )
         if result.returncode != 0:
             return []
@@ -407,7 +407,7 @@ def _detect_ci_failures(project_root: Path) -> list[FailureInfo]:
         # Get failed job logs
         log_result = subprocess.run(
             ["gh", "run", "view", str(run_id), "--log-failed"],
-            capture_output=True, text=True, cwd=str(project_root),
+            capture_output=True, text=True, encoding="utf-8", cwd=str(project_root),
         )
         if log_result.returncode != 0:
             return []
@@ -561,7 +561,7 @@ def _run_local_tests(project_root: Path, config: dict[str, Any]) -> list[Failure
             test_command,
             shell=True,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             cwd=str(project_root),
             timeout=300,  # 5 min timeout
         )
@@ -1061,7 +1061,7 @@ def _git_push(project_root: Path) -> bool:
         )
         result = subprocess.run(
             ["git", "push"],
-            cwd=str(project_root), capture_output=True, text=True,
+            cwd=str(project_root), capture_output=True, text=True, encoding="utf-8",
         )
         return result.returncode == 0
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -1077,7 +1077,7 @@ def _watch_ci(project_root: Path) -> bool | None:
         result = subprocess.run(
             ["gh", "run", "watch", "--exit-status"],
             cwd=str(project_root),
-            capture_output=True, text=True,
+            capture_output=True, text=True, encoding="utf-8",
             timeout=600,  # 10 min max
         )
         return result.returncode == 0
@@ -1094,7 +1094,7 @@ def _has_gh_cli() -> bool:
     """Check if `gh` CLI is available."""
     try:
         result = subprocess.run(
-            ["gh", "--version"], capture_output=True, text=True,
+            ["gh", "--version"], capture_output=True, text=True, encoding="utf-8",
         )
         return result.returncode == 0
     except FileNotFoundError:

--- a/codd/generator.py
+++ b/codd/generator.py
@@ -731,7 +731,7 @@ def _invoke_file_writing_agent(
 
     try:
         result = subprocess.run(
-            command, input=prompt, capture_output=True, text=True,
+            command, input=prompt, capture_output=True, text=True, encoding="utf-8",
             check=False, cwd=cwd, timeout=3600,
         )
     except FileNotFoundError as exc:
@@ -754,11 +754,11 @@ def _invoke_file_writing_agent(
     # Detect files changed by the agent (unstaged vs index = agent's work)
     diff_out = subprocess.run(
         ["git", "diff", "--name-only"],
-        cwd=cwd, capture_output=True, text=True,
+        cwd=cwd, capture_output=True, text=True, encoding="utf-8",
     ).stdout.strip()
     untracked_out = subprocess.run(
         ["git", "ls-files", "--others", "--exclude-standard"],
-        cwd=cwd, capture_output=True, text=True,
+        cwd=cwd, capture_output=True, text=True, encoding="utf-8",
     ).stdout.strip()
 
     changed_files = diff_out.splitlines() if diff_out else []
@@ -807,7 +807,7 @@ def _invoke_ai_command(
             command,
             input=prompt,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             check=False,
         )
     except FileNotFoundError as exc:

--- a/codd/graph.py
+++ b/codd/graph.py
@@ -37,14 +37,14 @@ class CEG:
     def _load(self):
         """Load JSONL files into memory."""
         if self.nodes_path.exists():
-            for line in self.nodes_path.read_text().splitlines():
+            for line in self.nodes_path.read_text(encoding="utf-8").splitlines():
                 line = line.strip()
                 if line:
                     node = json.loads(line)
                     self.nodes[node["id"]] = node
 
         if self.edges_path.exists():
-            for line in self.edges_path.read_text().splitlines():
+            for line in self.edges_path.read_text(encoding="utf-8").splitlines():
                 line = line.strip()
                 if line:
                     edge = json.loads(line)
@@ -61,13 +61,13 @@ class CEG:
         """Write all data back to JSONL files."""
         # Sort nodes by id for stable output
         sorted_nodes = sorted(self.nodes.values(), key=lambda n: n["id"])
-        with open(self.nodes_path, "w") as f:
+        with open(self.nodes_path, "w", encoding="utf-8") as f:
             for node in sorted_nodes:
                 f.write(json.dumps(node, ensure_ascii=False) + "\n")
 
         # Sort edges by id for stable output
         sorted_edges = sorted(self.edges, key=lambda e: e.get("id", 0))
-        with open(self.edges_path, "w") as f:
+        with open(self.edges_path, "w", encoding="utf-8") as f:
             for edge in sorted_edges:
                 f.write(json.dumps(edge, ensure_ascii=False) + "\n")
 

--- a/codd/hooks/__init__.py
+++ b/codd/hooks/__init__.py
@@ -78,7 +78,7 @@ def _get_staged_markdown_files(project_root: Path, config: dict) -> list[Path]:
         ["git", "-c", "core.quotePath=false", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
         cwd=project_root,
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8",
         check=False,
     )
     if result.returncode != 0:

--- a/codd/measure.py
+++ b/codd/measure.py
@@ -240,7 +240,7 @@ def _collect_coverage_metrics(
 def _extract_source_refs(doc_path: Path, tracked: set[str]) -> None:
     """Extract source file references from a design document's frontmatter."""
     try:
-        content = doc_path.read_text(errors="ignore")
+        content = doc_path.read_text(encoding="utf-8", errors="ignore")
     except OSError:
         return
 

--- a/codd/policy.py
+++ b/codd/policy.py
@@ -138,7 +138,7 @@ def _run_policy_oss(
 
         result.files_checked += 1
         try:
-            content = file_path.read_text(errors="ignore")
+            content = file_path.read_text(encoding="utf-8", errors="ignore")
         except OSError:
             continue
 

--- a/codd/propagate.py
+++ b/codd/propagate.py
@@ -13,7 +13,7 @@ from codd.scanner import _extract_frontmatter
 def run_impact(project_root: Path, codd_dir: Path, diff_target: str,
                output_path: str = None):
     """Run impact analysis from git diff."""
-    config = yaml.safe_load((codd_dir / "codd.yaml").read_text())
+    config = yaml.safe_load((codd_dir / "codd.yaml").read_text(encoding="utf-8"))
     scan_dir = codd_dir / "scan"
     ceg = CEG(scan_dir)
 
@@ -62,7 +62,7 @@ def run_impact(project_root: Path, codd_dir: Path, diff_target: str,
     )
 
     if output_path:
-        Path(output_path).write_text(report)
+        Path(output_path).write_text(report, encoding="utf-8")
         print(f"Report written to {output_path}")
     else:
         print("\n" + report)

--- a/codd/propagate.py
+++ b/codd/propagate.py
@@ -75,7 +75,7 @@ def _get_changed_files(project_root: Path, diff_target: str) -> list:
     try:
         result = subprocess.run(
             ["git", "-c", "core.quotePath=false", "diff", "--name-only", diff_target],
-            capture_output=True, text=True, cwd=str(project_root)
+            capture_output=True, text=True, encoding="utf-8", cwd=str(project_root)
         )
         if result.returncode != 0:
             print(f"Warning: git diff failed: {result.stderr.strip()}")

--- a/codd/propagator.py
+++ b/codd/propagator.py
@@ -509,7 +509,7 @@ def _git_commit_propagation(
     try:
         add_result = subprocess.run(
             ["git", "add"] + files,
-            cwd=str(project_root), capture_output=True, text=True,
+            cwd=str(project_root), capture_output=True, text=True, encoding="utf-8",
         )
         if add_result.returncode != 0:
             logger.warning("git add failed: %s", add_result.stderr.strip())
@@ -520,7 +520,7 @@ def _git_commit_propagation(
             msg += f"\n\n{reason}"
         commit_result = subprocess.run(
             ["git", "commit", "-m", msg],
-            cwd=str(project_root), capture_output=True, text=True,
+            cwd=str(project_root), capture_output=True, text=True, encoding="utf-8",
         )
         if commit_result.returncode != 0:
             logger.warning("git commit failed: %s", commit_result.stderr.strip())
@@ -533,7 +533,7 @@ def _get_changed_files(project_root: Path, diff_target: str) -> list[str]:
     try:
         result = subprocess.run(
             ["git", "-c", "core.quotePath=false", "diff", "--name-only", diff_target],
-            capture_output=True, text=True, cwd=str(project_root),
+            capture_output=True, text=True, encoding="utf-8", cwd=str(project_root),
         )
         if result.returncode != 0:
             return []
@@ -756,7 +756,7 @@ def _get_code_diff(
     try:
         result = subprocess.run(
             ["git", "-c", "core.quotePath=false", "diff", diff_target, "--"] + files,
-            capture_output=True, text=True, cwd=str(project_root),
+            capture_output=True, text=True, encoding="utf-8", cwd=str(project_root),
         )
         if result.returncode != 0:
             return ""

--- a/codd/repair_slice.py
+++ b/codd/repair_slice.py
@@ -280,7 +280,7 @@ def build_repair_slice(
     if not full_path.exists():
         return RepairSlice(file=file_path, module_name=module_name)
 
-    content = full_path.read_text(errors="ignore")
+    content = full_path.read_text(encoding="utf-8", errors="ignore")
     language = facts.language or "python"
 
     # Extract line ranges (all functions, including private)

--- a/codd/scanner.py
+++ b/codd/scanner.py
@@ -116,7 +116,7 @@ def _extract_frontmatter(file_path: Path) -> dict | None:
       # Document content
     """
     try:
-        content = file_path.read_text(errors="ignore")
+        content = file_path.read_text(encoding="utf-8", errors="ignore")
     except Exception:
         return None
 
@@ -366,7 +366,7 @@ def _extract_imports_basic(ceg: CEG, project_root: Path, src_dir: Path, file_pat
                            rel_path: str, language: str):
     """Basic import extraction using the shared parsing backend."""
     try:
-        content = file_path.read_text(errors="ignore")
+        content = file_path.read_text(encoding="utf-8", errors="ignore")
     except Exception:
         return
 

--- a/codd/scanner.py
+++ b/codd/scanner.py
@@ -28,7 +28,7 @@ def run_scan(project_root: Path, codd_dir: Path):
         print("Error: codd/codd.yaml not found.")
         raise SystemExit(1)
 
-    config = yaml.safe_load(config_path.read_text())
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     scan_dir = codd_dir / "scan"
 
     ceg = CEG(scan_dir)
@@ -247,21 +247,21 @@ def _load_legacy_annotations(ceg: CEG, annotations_dir: Path):
 
     conv_path = annotations_dir / "conventions.yaml"
     if conv_path.exists():
-        data = yaml.safe_load(conv_path.read_text())
+        data = yaml.safe_load(conv_path.read_text(encoding="utf-8"))
         for conv in (data or {}).get("conventions", []):
             _load_legacy_convention(ceg, conv)
             loaded = True
 
     links_path = annotations_dir / "doc_links.yaml"
     if links_path.exists():
-        data = yaml.safe_load(links_path.read_text())
+        data = yaml.safe_load(links_path.read_text(encoding="utf-8"))
         for link in (data or {}).get("links", []):
             _load_legacy_doc_link(ceg, link)
             loaded = True
 
     deps_path = annotations_dir / "data_dependencies.yaml"
     if deps_path.exists():
-        data = yaml.safe_load(deps_path.read_text())
+        data = yaml.safe_load(deps_path.read_text(encoding="utf-8"))
         for dep in (data or {}).get("data_dependencies", []):
             _load_legacy_data_dependency(ceg, dep)
             loaded = True

--- a/codd/schema_refs.py
+++ b/codd/schema_refs.py
@@ -114,7 +114,7 @@ def build_schema_refs(facts: ProjectFacts, project_root: Path) -> None:
         for rel_file in mod.files:
             full = project_root / rel_file
             try:
-                content = full.read_text(errors="ignore")
+                content = full.read_text(encoding="utf-8", errors="ignore")
             except Exception:
                 continue
             refs = detect_schema_refs(content, rel_file)

--- a/codd/traceability.py
+++ b/codd/traceability.py
@@ -43,7 +43,7 @@ def build_test_traceability(facts: ProjectFacts, project_root: Path) -> None:
             # Read test file and scan for symbol references
             test_path = project_root / test_detail.file_path
             try:
-                test_content = test_path.read_text(errors="ignore")
+                test_content = test_path.read_text(encoding="utf-8", errors="ignore")
             except Exception:
                 continue
             # Any source symbol name that appears in the test file = covered

--- a/codd/validator.py
+++ b/codd/validator.py
@@ -149,7 +149,7 @@ def _validate_project_oss(project_root: Path, codd_dir: Path | None = None) -> V
     """Validate CoDD frontmatter, references, wave config, and dependency cycles."""
     codd_dir = codd_dir or (project_root / "codd")
     config_path = codd_dir / "codd.yaml"
-    config = yaml.safe_load(config_path.read_text()) or {}
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
 
     result = ValidationResult()
     documents: dict[str, DocumentRecord] = {}
@@ -467,7 +467,7 @@ def _load_scanned_node_ids(project_root: Path, config: dict[str, Any]) -> set[st
         return set()
 
     node_ids: set[str] = set()
-    for line in nodes_path.read_text().splitlines():
+    for line in nodes_path.read_text(encoding="utf-8").splitlines():
         payload = line.strip()
         if not payload:
             continue

--- a/codd/validator.py
+++ b/codd/validator.py
@@ -309,7 +309,7 @@ def _iter_doc_files(project_root: Path, config: dict[str, Any]):
 
 def _parse_codd_frontmatter(file_path: Path) -> FrontmatterParseResult:
     try:
-        content = file_path.read_text(errors="ignore")
+        content = file_path.read_text(encoding="utf-8", errors="ignore")
     except Exception as exc:
         return FrontmatterParseResult(
             error={

--- a/codd/wiring.py
+++ b/codd/wiring.py
@@ -138,7 +138,7 @@ def build_runtime_wires(facts: ProjectFacts, project_root: Path) -> None:
         for rel_file in mod.files:
             full = project_root / rel_file
             try:
-                content = full.read_text(errors="ignore")
+                content = full.read_text(encoding="utf-8", errors="ignore")
             except Exception:
                 continue
             wires = detect_runtime_wires(content, rel_file)

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -66,12 +66,12 @@ def test_collect_fragments_excludes_orphans(tmp_path):
     for slug in ["authentication", "database_foundation"]:
         task_dir = gen_base / slug
         task_dir.mkdir(parents=True)
-        (task_dir / "index.ts").write_text(f"// {slug}")
+        (task_dir / "index.ts").write_text(f"// {slug}", encoding="utf-8")
 
     # Create an orphan directory (old task that was renamed)
     orphan_dir = gen_base / "old_removed_task"
     orphan_dir.mkdir(parents=True)
-    (orphan_dir / "stale.ts").write_text("// should be excluded")
+    (orphan_dir / "stale.ts").write_text("// should be excluded", encoding="utf-8")
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -24,7 +24,7 @@ def python_project(tmp_path):
     # Source code
     src = tmp_path / "src"
     (src / "auth").mkdir(parents=True)
-    (src / "auth" / "__init__.py").write_text("")
+    (src / "auth" / "__init__.py").write_text("", encoding="utf-8")
     (src / "auth" / "service.py").write_text(textwrap.dedent("""\
         from db.models import User
         from utils.crypto import hash_password
@@ -47,7 +47,7 @@ def python_project(tmp_path):
     """))
 
     (src / "db").mkdir(parents=True)
-    (src / "db" / "__init__.py").write_text("")
+    (src / "db" / "__init__.py").write_text("", encoding="utf-8")
     (src / "db" / "models.py").write_text(textwrap.dedent("""\
         from sqlalchemy import Column, Integer, String
         from sqlalchemy.ext.declarative import declarative_base
@@ -68,7 +68,7 @@ def python_project(tmp_path):
     """))
 
     (src / "utils").mkdir(parents=True)
-    (src / "utils" / "__init__.py").write_text("")
+    (src / "utils" / "__init__.py").write_text("", encoding="utf-8")
     (src / "utils" / "crypto.py").write_text(textwrap.dedent("""\
         import hashlib
 
@@ -80,7 +80,7 @@ def python_project(tmp_path):
     """))
 
     (src / "api").mkdir(parents=True)
-    (src / "api" / "__init__.py").write_text("")
+    (src / "api" / "__init__.py").write_text("", encoding="utf-8")
     (src / "api" / "routes.py").write_text(textwrap.dedent("""\
         from fastapi import FastAPI
         from auth.service import AuthService
@@ -101,7 +101,7 @@ def python_project(tmp_path):
     # Tests
     tests = tmp_path / "tests"
     tests.mkdir()
-    (tests / "__init__.py").write_text("")
+    (tests / "__init__.py").write_text("", encoding="utf-8")
     (tests / "test_auth.py").write_text(textwrap.dedent("""\
         from auth.service import AuthService
 
@@ -268,7 +268,7 @@ class TestSynthDocs:
         assert system_ctx.exists()
         assert system_ctx in generated
 
-        content = system_ctx.read_text()
+        content = system_ctx.read_text(encoding="utf-8")
         assert "design:extract:system-context" in content
         assert "source: extracted" in content
         assert "Module Map" in content
@@ -283,7 +283,7 @@ class TestSynthDocs:
 
         auth_doc = modules_dir / "auth.md"
         assert auth_doc.exists()
-        content = auth_doc.read_text()
+        content = auth_doc.read_text(encoding="utf-8")
         assert "design:extract:auth" in content
         assert "AuthService" in content
         assert "source: extracted" in content
@@ -293,7 +293,7 @@ class TestSynthDocs:
         output_dir = python_project / "codd" / "extracted"
         synth_docs(facts, output_dir)
 
-        auth_doc = (output_dir / "modules" / "auth.md").read_text()
+        auth_doc = (output_dir / "modules" / "auth.md").read_text(encoding="utf-8")
         assert "depends_on:" in auth_doc
         assert "design:extract:db" in auth_doc
 
@@ -304,7 +304,7 @@ class TestSynthDocs:
         synth_docs(facts, output_dir)
 
         for f in (output_dir / "modules").iterdir():
-            content = f.read_text()
+            content = f.read_text(encoding="utf-8")
             # confidence should be < 0.90 (green threshold)
             import re
             m = re.search(r'confidence:\s*([\d.]+)', content)

--- a/tests/test_feedback_loop.py
+++ b/tests/test_feedback_loop.py
@@ -173,7 +173,7 @@ def test_generate_cli_feedback_flag(tmp_path, monkeypatch):
     project = _setup_cli_project(tmp_path)
     prompts: list[str] = []
 
-    def fake_run(command, *, input, capture_output, text, check):
+    def fake_run(command, *, input, capture_output, text, check, **kwargs):
         prompts.append(input)
         return subprocess.CompletedProcess(
             args=command, returncode=0,

--- a/tests/test_fixer.py
+++ b/tests/test_fixer.py
@@ -183,7 +183,7 @@ class TestInvokeFixAi:
 
         target = tmp_path / "src" / "api" / "route.ts"
         assert target.exists()
-        content = target.read_text()
+        content = target.read_text(encoding="utf-8")
         assert "export function GET()" in content
         assert "Response.json" in content
 
@@ -207,8 +207,8 @@ class TestInvokeFixAi:
         with patch("codd.fixer._invoke_ai_command", return_value=ai_response):
             _invoke_fix_ai("claude --print", ai_response, tmp_path)
 
-        assert (tmp_path / "src" / "a.ts").read_text() == "content_a\n"
-        assert (tmp_path / "src" / "b.ts").read_text() == "content_b\n"
+        assert (tmp_path / "src" / "a.ts").read_text(encoding="utf-8") == "content_a\n"
+        assert (tmp_path / "src" / "b.ts").read_text(encoding="utf-8") == "content_b\n"
 
     def test_fallback_preceded_by_bold_path(self, tmp_path):
         """Fallback: **path/to/file** on line before code block."""
@@ -223,7 +223,7 @@ class TestInvokeFixAi:
 
         target = tmp_path / "src" / "handler.ts"
         assert target.exists()
-        assert "fixed" in target.read_text()
+        assert "fixed" in target.read_text(encoding="utf-8")
 
     def test_fallback_comment_filepath(self, tmp_path):
         """Fallback: // filepath: path/to/file as first line in block."""
@@ -238,7 +238,7 @@ class TestInvokeFixAi:
 
         target = tmp_path / "src" / "utils.ts"
         assert target.exists()
-        assert "add" in target.read_text()
+        assert "add" in target.read_text(encoding="utf-8")
 
     def test_primary_pattern_takes_precedence(self, tmp_path):
         """Primary pattern wins when both primary and fallback match."""
@@ -250,7 +250,7 @@ class TestInvokeFixAi:
         with patch("codd.fixer._invoke_ai_command", return_value=ai_response):
             _invoke_fix_ai("claude --print", ai_response, tmp_path)
 
-        assert (tmp_path / "src" / "route.ts").read_text() == "primary_content\n"
+        assert (tmp_path / "src" / "route.ts").read_text(encoding="utf-8") == "primary_content\n"
 
 
 class TestPrepareFixAiCommand:
@@ -354,7 +354,7 @@ class TestInferImplPaths:
     def test_nextjs_api_route(self, tmp_path):
         route = tmp_path / "src" / "app" / "api" / "courses" / "route.ts"
         route.parent.mkdir(parents=True)
-        route.write_text("handler")
+        route.write_text("handler", encoding="utf-8")
 
         result = _infer_impl_paths(tmp_path, ["tests/e2e/courses.spec.ts"])
         assert "src/app/api/courses/route.ts" in result
@@ -362,7 +362,7 @@ class TestInferImplPaths:
     def test_kebab_case_variant(self, tmp_path):
         route = tmp_path / "src" / "app" / "api" / "lms-core" / "route.ts"
         route.parent.mkdir(parents=True)
-        route.write_text("handler")
+        route.write_text("handler", encoding="utf-8")
 
         result = _infer_impl_paths(tmp_path, ["tests/e2e/lms_core.spec.ts"])
         assert "src/app/api/lms-core/route.ts" in result
@@ -378,7 +378,7 @@ class TestInferImplPaths:
     def test_deduplicates(self, tmp_path):
         route = tmp_path / "src" / "app" / "api" / "auth" / "route.ts"
         route.parent.mkdir(parents=True)
-        route.write_text("handler")
+        route.write_text("handler", encoding="utf-8")
 
         result = _infer_impl_paths(tmp_path, [
             "tests/e2e/auth.spec.ts",
@@ -430,7 +430,7 @@ class TestFindRouteFilesForEndpoints:
     def test_finds_standard_route(self, tmp_path):
         route = tmp_path / "src" / "app" / "api" / "enrollments" / "route.ts"
         route.parent.mkdir(parents=True)
-        route.write_text("handler")
+        route.write_text("handler", encoding="utf-8")
 
         result = _find_route_files_for_endpoints(tmp_path, ["/api/enrollments"])
         assert any("enrollments/route.ts" in p for p in result)
@@ -439,7 +439,7 @@ class TestFindRouteFilesForEndpoints:
         """Finds routes in generated/ subdirectories (osato-lms pattern)."""
         route = tmp_path / "src" / "generated" / "sprint_1" / "api" / "enrollments" / "route.ts"
         route.parent.mkdir(parents=True)
-        route.write_text("handler")
+        route.write_text("handler", encoding="utf-8")
 
         result = _find_route_files_for_endpoints(tmp_path, ["/api/enrollments"])
         assert any("enrollments/route.ts" in p for p in result)
@@ -447,7 +447,7 @@ class TestFindRouteFilesForEndpoints:
     def test_finds_nested_route(self, tmp_path):
         route = tmp_path / "src" / "app" / "api" / "admin" / "roles" / "route.ts"
         route.parent.mkdir(parents=True)
-        route.write_text("handler")
+        route.write_text("handler", encoding="utf-8")
 
         result = _find_route_files_for_endpoints(tmp_path, ["/api/admin/roles"])
         assert any("admin/roles/route.ts" in p for p in result)
@@ -458,7 +458,7 @@ class TestFindImplCandidatesGlob:
         """Strategy 1 glob finds routes in non-standard locations."""
         route = tmp_path / "src" / "generated" / "v1" / "app" / "api" / "courses" / "route.ts"
         route.parent.mkdir(parents=True)
-        route.write_text("handler")
+        route.write_text("handler", encoding="utf-8")
 
         result = _find_impl_candidates(tmp_path, "courses")
         assert any("courses/route.ts" in p for p in result)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -102,7 +102,7 @@ Tenant isolation and audit logging are mandatory.
 def mock_ai_cli(monkeypatch):
     calls: list[dict[str, object]] = []
 
-    def fake_run(command, *, input, capture_output, text, check):
+    def fake_run(command, *, input, capture_output, text, check, **kwargs):
         stdout = "# Generated Content\n\n## Overview\n\nThis document contains concrete content.\n"
         if "docs/detailed_design/" in input:
             stdout = (

--- a/tests/test_implement.py
+++ b/tests/test_implement.py
@@ -212,7 +212,7 @@ Tasks for auth and tenant foundations.
 def mock_implement_ai(monkeypatch):
     calls: list[dict[str, object]] = []
 
-    def fake_run(command, *, input, capture_output, text, check):
+    def fake_run(command, *, input, capture_output, text, check, **kwargs):
         match = re.search(r"Output directory: (?P<output>src/generated/[^\n]+)", input)
         assert match is not None
         output_dir = match.group("output")
@@ -322,7 +322,7 @@ def test_implement_respects_python_project_language(tmp_path, monkeypatch):
 
     calls: list[dict[str, object]] = []
 
-    def fake_run(command, *, input, capture_output, text, check):
+    def fake_run(command, *, input, capture_output, text, check, **kwargs):
         match = re.search(r"Output directory: (?P<output>src/generated/[^\n]+)", input)
         assert match is not None
         output_dir = match.group("output")
@@ -381,7 +381,7 @@ def test_implement_fallback_uses_rust_extension(tmp_path, monkeypatch):
 
     calls: list[dict[str, object]] = []
 
-    def fake_run(command, *, input, capture_output, text, check):
+    def fake_run(command, *, input, capture_output, text, check, **kwargs):
         calls.append({"command": command, "input": input})
         return subprocess.CompletedProcess(
             args=command,
@@ -850,7 +850,7 @@ def test_implement_skips_downstream_on_failure(tmp_path, monkeypatch):
 
     call_count = {"n": 0}
 
-    def fake_run(command, *, input, capture_output, text, check):
+    def fake_run(command, *, input, capture_output, text, check, **kwargs):
         call_count["n"] += 1
         task_match = re.search(r"Task ID: (m\d+\.\d+)", input)
         task_id = task_match.group(1) if task_match else "?"

--- a/tests/test_implement.py
+++ b/tests/test_implement.py
@@ -427,7 +427,7 @@ def test_implement_clean_removes_existing_generated_output(tmp_path, mock_implem
     stale_dir = project / "src" / "generated" / "old_task"
     stale_dir.mkdir(parents=True)
     stale_file = stale_dir / "stale.ts"
-    stale_file.write_text("// stale")
+    stale_file.write_text("// stale", encoding="utf-8")
 
     runner = CliRunner()
     result = runner.invoke(main, ["implement", "--path", str(project), "--clean"])
@@ -457,7 +457,7 @@ def test_get_valid_task_slugs_no_plan(tmp_path):
     project.mkdir()
     codd_dir = project / "codd"
     codd_dir.mkdir()
-    (codd_dir / "codd.yaml").write_text("project:\n  name: demo\n  language: typescript\n")
+    (codd_dir / "codd.yaml").write_text("project:\n  name: demo\n  language: typescript\n", encoding="utf-8")
 
     result = get_valid_task_slugs(project)
     assert result == set()

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -165,7 +165,7 @@ def _plan_by_node(project: Path):
 def mock_plan_init_ai(monkeypatch):
     calls: list[dict[str, object]] = []
 
-    def fake_run(command, *, input, capture_output, text, check):
+    def fake_run(command, *, input, capture_output, text, check, **kwargs):
         calls.append(
             {
                 "command": command,
@@ -262,7 +262,7 @@ def test_plan_init_accepts_detailed_design_artifacts_from_ai(tmp_path, monkeypat
     conventions: []
 """
 
-    def fake_run(command, *, input, capture_output, text, check):
+    def fake_run(command, *, input, capture_output, text, check, **kwargs):
         return subprocess.CompletedProcess(
             args=command,
             returncode=0,
@@ -714,7 +714,7 @@ def _write_extracted_docs(project: Path):
 def mock_brownfield_ai(monkeypatch):
     calls: list[dict[str, object]] = []
 
-    def fake_run(command, *, input, capture_output, text, check):
+    def fake_run(command, *, input, capture_output, text, check, **kwargs):
         calls.append(
             {
                 "command": command,

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -372,7 +372,7 @@ def test_plan_marks_all_waves_done_when_all_outputs_validate(tmp_path):
     # After creating extracted docs, baseline becomes DONE
     extracted_dir = project / "codd" / "extracted"
     extracted_dir.mkdir(parents=True)
-    (extracted_dir / "system-context.md").write_text("# extracted\n")
+    (extracted_dir / "system-context.md").write_text("# extracted\n", encoding="utf-8")
     plan2, _ = _plan_by_node(project)
     assert plan2.baseline_status == STATUS_DONE
     text2 = render_plan_text(plan2)

--- a/tests/test_propagate.py
+++ b/tests/test_propagate.py
@@ -27,7 +27,7 @@ codd:
 ---
 
 # FR-01
-""")
+""", encoding="utf-8")
     # Register node in graph
     ceg.upsert_node("req:FR-01", "requirement", path="docs/requirements.md")
 
@@ -62,7 +62,7 @@ codd:
 ---
 
 # System Design
-""")
+""", encoding="utf-8")
     ceg.upsert_node("design:system", "design", path="design.md")
 
     start_nodes = _resolve_start_nodes(ceg, tmp_path, ["design.md"])
@@ -204,7 +204,7 @@ def test_full_impact_from_document_change(tmp_path):
     (project / "docs").mkdir()
     codd_dir = project / "codd"
     codd_dir.mkdir()
-    (codd_dir / "codd.yaml").write_text(CoDD_YAML)
+    (codd_dir / "codd.yaml").write_text(CoDD_YAML, encoding="utf-8")
 
     # Create docs with frontmatter
     (project / "docs" / "db_design.md").write_text("""---
@@ -217,7 +217,7 @@ codd:
 ---
 
 # DB Design
-""")
+""", encoding="utf-8")
 
     (project / "docs" / "api_design.md").write_text("""---
 codd:
@@ -232,7 +232,7 @@ codd:
 ---
 
 # API Design
-""")
+""", encoding="utf-8")
 
     (project / "docs" / "ui_design.md").write_text("""---
 codd:
@@ -241,7 +241,7 @@ codd:
 ---
 
 # UI Design
-""")
+""", encoding="utf-8")
 
     # Scan to build graph
     run_scan(project, codd_dir)

--- a/tests/test_propagator.py
+++ b/tests/test_propagator.py
@@ -147,7 +147,7 @@ def _write_design_doc(
 def mock_propagate_ai(monkeypatch):
     calls: list[dict[str, object]] = []
 
-    def fake_run(command, *, input, capture_output, text, check):
+    def fake_run(command, *, input, capture_output, text, check, **kwargs):
         calls.append({"command": command, "input": input})
         # Return updated body
         return subprocess.CompletedProcess(

--- a/tests/test_propagator.py
+++ b/tests/test_propagator.py
@@ -94,7 +94,7 @@ def _setup_project(tmp_path: Path) -> Path:
 
     # Source files
     (project / "src" / "auth").mkdir(parents=True)
-    (project / "src" / "auth" / "service.py").write_text("class AuthService:\n    pass\n")
+    (project / "src" / "auth" / "service.py").write_text("class AuthService:\n    pass\n", encoding="utf-8")
     (project / "src" / "tasks").mkdir(parents=True)
     (project / "src" / "tasks" / "service.py").write_text("class TaskService:\n    pass\n")
 
@@ -204,7 +204,7 @@ def test_map_files_to_modules_multiple_source_dirs():
 
 def test_find_design_docs_by_modules(tmp_path):
     project = _setup_project(tmp_path)
-    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text())
+    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text(encoding="utf-8"))
 
     docs = _find_design_docs_by_modules(
         project, config, {"auth"}, {"src/auth/service.py": "auth"},
@@ -219,7 +219,7 @@ def test_find_design_docs_by_modules(tmp_path):
 
 def test_find_design_docs_excludes_unrelated_modules(tmp_path):
     project = _setup_project(tmp_path)
-    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text())
+    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text(encoding="utf-8"))
 
     docs = _find_design_docs_by_modules(
         project, config, {"notifications"}, {"src/notifications/service.py": "notifications"},
@@ -234,7 +234,7 @@ def test_find_design_docs_excludes_unrelated_modules(tmp_path):
 
 def test_find_design_docs_returns_empty_for_unknown_module(tmp_path):
     project = _setup_project(tmp_path)
-    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text())
+    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text(encoding="utf-8"))
 
     docs = _find_design_docs_by_modules(
         project, config, {"billing"}, {"src/billing/service.py": "billing"},
@@ -472,7 +472,7 @@ def test_get_doc_confidence_with_graph(tmp_path):
     from codd.graph import CEG
 
     project = _setup_project(tmp_path)
-    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text())
+    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text(encoding="utf-8"))
     _setup_graph(project, config)
 
     graph_path = project / config["graph"]["path"]
@@ -505,7 +505,7 @@ def test_get_doc_confidence_without_graph():
 def test_classify_docs_by_band(tmp_path):
     """Docs are classified into green/amber/gray based on graph evidence."""
     project = _setup_project(tmp_path)
-    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text())
+    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text(encoding="utf-8"))
     _setup_graph(project, config)
 
     bands_config = config.get("bands", {})
@@ -569,7 +569,7 @@ def test_verify_state_save_load_clear(tmp_path):
 def test_run_verify_splits_by_band(tmp_path, monkeypatch):
     """run_verify auto-applies green band and returns HITL list for amber/gray."""
     project = _setup_project(tmp_path)
-    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text())
+    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text(encoding="utf-8"))
     _setup_graph(project, config)
     ai_calls: list[dict] = []
 
@@ -643,7 +643,7 @@ def test_run_verify_no_graph_all_amber(tmp_path, monkeypatch):
 def test_run_commit_records_knowledge(tmp_path, monkeypatch):
     """run_commit records HITL corrections as human evidence."""
     project = _setup_project(tmp_path)
-    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text())
+    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text(encoding="utf-8"))
     _setup_graph(project, config)
 
     # Save a fake verify state with HITL docs
@@ -715,7 +715,7 @@ def test_propagate_cli_verify_mode(tmp_path, monkeypatch):
     from click.testing import CliRunner
 
     project = _setup_project(tmp_path)
-    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text())
+    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text(encoding="utf-8"))
     _setup_graph(project, config)
 
     def patched_subprocess(command, *, capture_output=False, text=False,
@@ -751,7 +751,7 @@ def test_propagate_cli_commit_mode(tmp_path, monkeypatch):
     from click.testing import CliRunner
 
     project = _setup_project(tmp_path)
-    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text())
+    config = yaml.safe_load((project / "codd" / "codd.yaml").read_text(encoding="utf-8"))
     _setup_graph(project, config)
 
     # Create verify state

--- a/tests/test_repair_slice.py
+++ b/tests/test_repair_slice.py
@@ -97,7 +97,7 @@ class TestExtractFunctionLineRanges:
                 def method(self):
                     return 3
         """)
-        (tmp_path / "test.py").write_text(code)
+        (tmp_path / "test.py").write_text(code, encoding="utf-8")
         ranges = extract_function_line_ranges(code, "test.py", "python")
         assert "foo" in ranges
         assert "bar" in ranges
@@ -187,7 +187,7 @@ class TestBuildRepairSlice:
                 return 3
         """)
         (tmp_path / "src").mkdir()
-        (tmp_path / "src" / "mod.py").write_text(code)
+        (tmp_path / "src" / "mod.py").write_text(code, encoding="utf-8")
 
         mod = ModuleInfo(
             name="mod",
@@ -208,7 +208,7 @@ class TestBuildRepairSlice:
         assert rs.functions[0].name in ("bar", "baz", "foo")
 
     def test_empty_file(self, tmp_path):
-        (tmp_path / "empty.py").write_text("")
+        (tmp_path / "empty.py").write_text("", encoding="utf-8")
         facts = make_facts()
         rs = build_repair_slice(tmp_path, "empty.py", facts)
         assert rs.functions == []
@@ -220,7 +220,7 @@ class TestBuildRepairSlice:
 
     def test_top_n_limits(self, tmp_path):
         code = "\n".join(f"def func_{i}():\n    return {i}\n" for i in range(10))
-        (tmp_path / "many.py").write_text(code)
+        (tmp_path / "many.py").write_text(code, encoding="utf-8")
 
         syms = [make_symbol(f"func_{i}", line=i * 3 + 1) for i in range(10)]
         mod = ModuleInfo(name="many", files=["many.py"], symbols=syms, call_edges=[])
@@ -237,7 +237,7 @@ class TestBuildRepairSlice:
             def callee():
                 return 42
         """)
-        (tmp_path / "call.py").write_text(code)
+        (tmp_path / "call.py").write_text(code, encoding="utf-8")
 
         mod = ModuleInfo(
             name="call",
@@ -312,7 +312,7 @@ class TestGenerateRepairSlices:
     def test_end_to_end(self, tmp_path):
         src = tmp_path / "src"
         src.mkdir()
-        (src / "__init__.py").write_text("")
+        (src / "__init__.py").write_text("", encoding="utf-8")
         (src / "main.py").write_text(textwrap.dedent("""\
             def process(data):
                 if not data:

--- a/tests/test_require.py
+++ b/tests/test_require.py
@@ -134,7 +134,7 @@ def _make_require_body(prompt: str) -> str:
 def mock_require_ai(monkeypatch):
     calls: list[dict[str, object]] = []
 
-    def fake_run(command, *, input, capture_output, text, check):
+    def fake_run(command, *, input, capture_output, text, check, **kwargs):
         calls.append({"command": command, "input": input})
         return subprocess.CompletedProcess(
             args=command,

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -259,7 +259,7 @@ def _make_restored_body(input_text: str) -> str:
 def mock_restore_ai(monkeypatch):
     calls: list[dict[str, object]] = []
 
-    def fake_run(command, *, input, capture_output, text, check):
+    def fake_run(command, *, input, capture_output, text, check, **kwargs):
         stdout = _make_restored_body(input)
         calls.append({"command": command, "input": input})
         return subprocess.CompletedProcess(

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -334,7 +334,7 @@ def test_restore_skips_existing_docs(tmp_path, mock_restore_ai):
     # Create the output file first
     doc_path = project / "docs" / "test" / "acceptance_criteria.md"
     doc_path.parent.mkdir(parents=True, exist_ok=True)
-    doc_path.write_text("# existing\n")
+    doc_path.write_text("# existing\n", encoding="utf-8")
 
     results = restore_wave(project, wave=1)
     assert results[0].status == "skipped"

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -50,7 +50,7 @@ title: Just a normal document
 
 def test_extract_frontmatter_no_frontmatter(tmp_path):
     doc = tmp_path / "test.md"
-    doc.write_text("# No frontmatter here\n")
+    doc.write_text("# No frontmatter here\n", encoding="utf-8")
     result = _extract_frontmatter(doc)
     assert result is None
 
@@ -275,7 +275,7 @@ def test_scan_warns_when_wave_config_output_is_missing(tmp_path, capsys):
 
     project, codd_dir = _setup_project(tmp_path)
     config_path = codd_dir / "codd.yaml"
-    config = yaml.safe_load(config_path.read_text())
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     config["wave_config"] = {
         "1": [
             {

--- a/tests/test_synth_templates.py
+++ b/tests/test_synth_templates.py
@@ -14,7 +14,7 @@ def _seed_synth_project(tmp_path: Path) -> Path:
     (src / "db").mkdir(parents=True)
     (src / "utils").mkdir(parents=True)
 
-    (src / "api" / "__init__.py").write_text("")
+    (src / "api" / "__init__.py").write_text("", encoding="utf-8")
     (src / "api" / "routes.py").write_text(
         textwrap.dedent(
             """\
@@ -31,7 +31,7 @@ def _seed_synth_project(tmp_path: Path) -> Path:
         )
     )
 
-    (src / "services" / "__init__.py").write_text("")
+    (src / "services" / "__init__.py").write_text("", encoding="utf-8")
     (src / "services" / "auth.py").write_text(
         textwrap.dedent(
             """\
@@ -48,7 +48,7 @@ def _seed_synth_project(tmp_path: Path) -> Path:
         )
     )
 
-    (src / "db" / "__init__.py").write_text("")
+    (src / "db" / "__init__.py").write_text("", encoding="utf-8")
     (src / "db" / "models.py").write_text(
         textwrap.dedent(
             """\
@@ -66,7 +66,7 @@ def _seed_synth_project(tmp_path: Path) -> Path:
         )
     )
 
-    (src / "utils" / "__init__.py").write_text("")
+    (src / "utils" / "__init__.py").write_text("", encoding="utf-8")
     (src / "utils" / "crypto.py").write_text(
         textwrap.dedent(
             """\
@@ -164,8 +164,8 @@ def test_synth_docs_renders_system_context_and_architecture(tmp_path):
     assert system_context in generated
     assert architecture in generated
 
-    system_content = system_context.read_text()
-    architecture_content = architecture.read_text()
+    system_content = system_context.read_text(encoding="utf-8")
+    architecture_content = architecture.read_text(encoding="utf-8")
 
     assert "Module Map" in system_content
     assert "Schema Artifacts" in system_content
@@ -182,7 +182,7 @@ def test_module_detail_includes_api_routes_and_async_functions(tmp_path):
     output_dir = project_root / "docs" / "extracted"
     synth_docs(facts, output_dir)
 
-    api_doc = (output_dir / "modules" / "api.md").read_text()
+    api_doc = (output_dir / "modules" / "api.md").read_text(encoding="utf-8")
 
     assert "## API Routes" in api_doc
     assert "`/health`" in api_doc
@@ -197,7 +197,7 @@ def test_schema_design_renders_foreign_keys_and_indexes(tmp_path):
     output_dir = project_root / "docs" / "extracted"
     synth_docs(facts, output_dir)
 
-    schema_doc = next((output_dir / "schemas").glob("*.md")).read_text()
+    schema_doc = next((output_dir / "schemas").glob("*.md")).read_text(encoding="utf-8")
 
     assert "## Foreign Keys" in schema_doc
     assert "users(role_id) -> roles(id)" in schema_doc
@@ -212,7 +212,7 @@ def test_api_contract_renders_openapi_endpoints(tmp_path):
     output_dir = project_root / "docs" / "extracted"
     synth_docs(facts, output_dir)
 
-    api_doc = next((output_dir / "api").glob("*.md")).read_text()
+    api_doc = next((output_dir / "api").glob("*.md")).read_text(encoding="utf-8")
 
     assert "## OpenAPI Endpoints" in api_doc
     assert "`/health`" in api_doc
@@ -252,7 +252,7 @@ def test_synth_architecture_classifies_layers_and_flags_violations(tmp_path):
     output_dir.mkdir(parents=True)
 
     architecture_path = synth_architecture(facts, output_dir)
-    content = architecture_path.read_text()
+    content = architecture_path.read_text(encoding="utf-8")
 
     assert "### Presentation" in content
     assert "### Application" in content

--- a/tests/test_traceability.py
+++ b/tests/test_traceability.py
@@ -162,7 +162,7 @@ def test_build_test_traceability_coverage_ratio_rounded(tmp_path):
     test_dir = tmp_path / "tests"
     test_dir.mkdir()
     # Only 1 of 3 symbols appears → ratio = 0.33
-    (test_dir / "test_mod.py").write_text("sym_a\n")
+    (test_dir / "test_mod.py").write_text("sym_a\n", encoding="utf-8")
 
     mod = ModuleInfo(name="mod")
     mod.symbols = [make_symbol("sym_a"), make_symbol("sym_b"), make_symbol("sym_c")]
@@ -179,7 +179,7 @@ def test_build_test_traceability_multiple_modules(tmp_path):
     """build_test_traceability processes all modules independently."""
     test_dir = tmp_path / "tests"
     test_dir.mkdir()
-    (test_dir / "test_a.py").write_text("func_a\n")
+    (test_dir / "test_a.py").write_text("func_a\n", encoding="utf-8")
     (test_dir / "test_b.py").write_text("func_b\n")
 
     mod_a = ModuleInfo(name="mod_a")

--- a/tests/test_tree_sitter_extractor.py
+++ b/tests/test_tree_sitter_extractor.py
@@ -10,9 +10,9 @@ def test_python_tree_sitter_extracts_multiline_signature_and_decorators(tmp_path
     src = tmp_path / "src"
     (src / "api").mkdir(parents=True)
     (src / "services").mkdir(parents=True)
-    (src / "services" / "__init__.py").write_text("")
-    (src / "services" / "auth.py").write_text("class AuthService:\n    pass\n")
-    (src / "api" / "__init__.py").write_text("")
+    (src / "services" / "__init__.py").write_text("", encoding="utf-8")
+    (src / "services" / "auth.py").write_text("class AuthService:\n    pass\n", encoding="utf-8")
+    (src / "api" / "__init__.py").write_text("", encoding="utf-8")
     (src / "api" / "routes.py").write_text(
         textwrap.dedent(
             """\

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -42,7 +42,7 @@ def _setup_project(tmp_path, docs: dict[str, str], wave_config=None):
     for relative_path, content in docs.items():
         doc_path = project / relative_path
         doc_path.parent.mkdir(parents=True, exist_ok=True)
-        doc_path.write_text(content)
+        doc_path.write_text(content, encoding="utf-8")
 
     return project, codd_dir
 
@@ -194,7 +194,7 @@ codd:
 """,
         },
     )
-    codd_config = yaml.safe_load((codd_dir / "codd.yaml").read_text())
+    codd_config = yaml.safe_load((codd_dir / "codd.yaml").read_text(encoding="utf-8"))
     codd_config["service_boundaries"] = [{"name": "auth", "modules": ["src/services/auth/"]}]
     (codd_dir / "codd.yaml").write_text(yaml.safe_dump(codd_config, sort_keys=False, allow_unicode=True))
 


### PR DESCRIPTION
Path.read_text(), Path.write_text(), and open() default to the system locale encoding when called without an explicit encoding. On Windows with an English locale (cp1252), this causes UnicodeDecodeError on codd/templates/gitignore.tmpl (which contains Japanese comments) - codd init crashes before it can write any project files.

Adds encoding="utf-8" to every read_text / write_text / open call in the codd/ package, and to the test files whose unencoded I/O caused test failures on Windows. Files whose existing content is ASCII still have unencoded I/O calls and therefore latent Windows bugs; those can be addressed in a follow-up.

Verified on Python 3.14, Windows English locale:
- codd init now succeeds end-to-end.
- 519 tests pass. Remaining 9 failures in tests/test_fixer.py are pre-existing Windows path-separator issues unrelated to encoding.