### PR TITLE
docs: update README (ja/en/zh) and CHANGELOG to v1.34.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ See [CHANGELOG.md](CHANGELOG.md) for details.
 
 ---
 
-## Case Study - osato-lms (LMS Web App)
+## Case Study — A Real-World LMS Project
 
-Result of running `codd verify --auto-repair --max-attempts 10` on the LMS project osato-lms (Next.js + Prisma + PostgreSQL):
+Result of running `codd verify --auto-repair --max-attempts 10` on a real-world LMS project (Next.js + Prisma + PostgreSQL):
 
 ```text
 status:                   PARTIAL_SUCCESS

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <p align="center">
-  <strong>CoDD — Coherence-Driven Development</strong><br>
-  <em>The evidence engine for change management in AI-assisted development.</em>
+  <strong>CoDD - Coherence-Driven Development</strong>
 </p>
 
 <p align="center">
@@ -16,1086 +15,222 @@
 
 ---
 
-> *When code changes, CoDD traces what's affected, checks what's violated, and produces the evidence trail for your merge decision.*
+## Write requirements + constraints. CoDD does the rest.
 
-```
+CoDD is a development engine that treats **requirements -> design -> implementation -> tests** as one DAG, mechanically verifies the coherence of every node, and lets an LLM repair inconsistencies automatically when they appear.
+
+Humans write only **what to build** and **where the boundaries are**. CoDD and the LLM take care of **how to build it**.
+
+```bash
 pip install codd-dev
 ```
 
-## 🆕 v1.19.0 — Screen Transition Edge 完全対応
-
-CoDD が **画面遷移エッジ** (Link / redirect / router.push / signIn callback) を扱える
-ようになった節目のリリース。これまで「ノード only」だった screen-flow 抽出に **edge** を
-追加し、validate / e2e-generate / drift / implementer 全層で transition を一気通貫に
-管理できる。
-
-| コマンド | 役割 |
-|---|---|
-| `codd extract --layer routes-edges` | tree-sitter AST で `<Link>`/`redirect`/`router.push` 等を抽出 → `screen-transitions.yaml` |
-| `codd e2e-generate --mode transitions` | transitions.yaml から `goto → click → toHaveURL` 形式の Playwright/Cypress テスト自動生成 |
-| `codd validate --screen-flow --edges` | edge 整合性 + orphan / dead-end / unknown_node 検出 + coverage gate |
-| `codd drift --e2e` | 設計書 transition vs E2E `toHaveURL` assertion 差分検知 → Coherence Engine DriftEvent |
-| `implement` wrapper rules (cmd_368) | thin wrapper の callback wiring 必須化 + middleware.ts 二重存在 ERROR |
-
-```bash
-codd extract --layer routes-edges               # screen-transitions.yaml 生成
-codd e2e-generate --mode transitions            # 遷移テスト自動生成
-codd validate --screen-flow --edges             # edge 整合性 + orphan 検知
-codd drift --e2e                                # 設計 vs E2E assertion drift
-codd coverage --edge-threshold 0                # CI で edge drift をブロック
-```
-
-framework 固有 transition pattern (Next.js / NextAuth / Clerk / Nuxt / SvelteKit / Astro /
-Remix 等) は `codd/screen_transitions/defaults.yaml` に分離、`codd.yaml [screen_transitions]`
-で project ごとに override 可能。CoDD core にはハードコードなし。テスト 915 PASS / 0 FAIL /
-0 SKIP (v1.18.0 852 → v1.19.0 +63)。
-
 ---
 
-## 🆕 v1.18.0 — screen-flow 完全統合 + UX surface coverage
+## Quick Start (5 min)
 
-`codd validate --screen-flow` の盲点 (filesystem_routes 設定ミス時 silent OK) を塞ぎ、
-`CoverageAuditor` に **auth_ui_surface** (login / root / signup) セクションを追加、
-さらに `codd implement` が **screen-flow.md** を AI prompt に inject するよう改修。
-UI route が page 生成リストから漏れて 404 になる従来の事故源を構造的に解消。
-
-| 改修 | 効果 |
-|---|---|
-| `validate --screen-flow` `CoddCLIError` 昇格 | base_dir 誤設定で routes 0 件のとき即停止、configured 値を明示 |
-| `coverage --screen-flow-threshold` | CI gate で screen-flow drift をブロック |
-| CoverageAuditor `ux:auth:signin/signup` + `ux:landing:root` | UX surface 欠落を ASK class で人間レビュー要求 |
-| `codd.yaml [ux] required_routes` override | NextAuth/Clerk/nuxt-auth 等の慣例差を project ごとに上書き |
-| `implement` screen-flow.md inject + `_is_ui_task` 検出 | UI task が page 生成リストから漏れない |
-| 0-file generation `CoddCLIError` (skip_generation: true 例外) | silent pass を排除、意図的 skip は明示要求 |
-
-```bash
-codd validate --screen-flow              # base_dir 誤設定で即 ERROR
-codd coverage --screen-flow-threshold 0  # CI gate (default: 0 drift)
-codd implement                            # UI task は screen-flow.md inject、0 file は ERROR
-```
-
-Generality Gate: framework 固有名 (NextAuth / Clerk 等) は依存検出列挙 + codd.yaml override
-で吸収。CoDD core にはハードコードなし。テスト 852 PASS / 0 FAIL / 0 SKIP。
-
----
-
-## 🆕 v1.17.0 — `codd deploy` + 双方向伝搬パス完成
-
-整合性駆動が「設計→実装→デプロイ」を一気通貫に統合する v1.17.0 リリース。
-
-| コマンド | 役割 |
-|---|---|
-| `codd deploy --target vps --apply` | `deploy.yaml` ベースで VPS (Docker Compose) / Azure App Service へデプロイ。dry-run デフォルト + healthcheck + auto rollback |
-| `codd propagate --reverse` | DESIGN.md / lexicon の git 変更を検知 → Coherence Engine の DriftEvent として逆伝搬 |
-| `codd require --propagate` | requirements.md frontmatter 変更を CEG `depends_on` 逆走 → 関連設計書を AI 更新提案 |
-| `codd validate --screen-flow` | screen-flow.md の routes と filesystem routes の drift 検出 |
-| `codd coverage` | E2E + design-token + lexicon の統合 coverage gate (CI exit code 1 on fail) |
-
-```bash
-# deploy
-codd deploy --target vps --apply
-codd deploy --target azure --apply
-
-# 双方向伝搬
-codd propagate --reverse --source design_token --apply
-codd require --propagate --apply
-
-# 品質ゲート
-codd validate --screen-flow
-codd coverage --e2e-threshold 100 --lexicon-threshold 100 --json
-```
-
-deploy target は `@register_target` デコレータで plug-in 追加可能 (cmd_344 fixup-drift Strategy
-と同思想)。Generality Gate 適合: Docker / Azure / SSH は target plug-in 内に閉じ、core は
-`DeployTarget` 抽象のみ。テスト 821 PASS / 0 FAIL / 0 SKIP。
-
----
-
-## 🆕 v1.16.0 — `codd fixup-drift` (Coherence Engine の自動修正出口)
-
-`codd fixup-drift` で Coherence Engine 検知 drift を自動修正。**デフォルト `--dry-run`** で本流を保護し、`--apply` 指定時は **git worktree 隔離** で適用 (失敗時は worktree 破棄で本流無傷)。
-
-```bash
-codd fixup-drift                                              # dry-run / red / all kinds
-codd fixup-drift --apply --severity red --kind url_drift      # worktree で適用
-codd fixup-drift --dry-run --severity all --kind design_token_drift
-```
-
-| Strategy | 振る舞い |
-|---|---|
-| `UrlDriftFixStrategy` | URL drift は **HITL only** (pending_hitl.md に記録) |
-| `DesignTokenDriftFixStrategy` | 大小文字統一など safe な正規化は auto-apply、値変更/削除は HITL |
-| `LexiconViolationFixStrategy` | lexicon 違反 (用語規約・circular dependency) は **HITL only** |
-
-新しい Fix Strategy は `@register_strategy("kind_name")` デコレータで plug-in 登録できる。
-
----
-
-## 🆕 v1.16.0-alpha — Coherence Engine (整合性駆動の中央ハブ)
-
-**drift / validate / propagate / fix を DriftEvent 統一フォーマットで結ぶ中央ハブ。**
-
-| コンポーネント | 役割 |
-|----------------|------|
-| `DriftEvent` | source/target/change_type/payload/severity/fix_strategy/kind を持つ統一イベント型 |
-| `EventBus` | in-process pub/sub。Detector が publish、Orchestrator が subscribe |
-| `Orchestrator` | severity ルーティング: `red` → auto-fix / `amber` → pending HITL / `green` → log |
-| `coherence_adapters` | drift / validate / design-token violation 出力 → DriftEvent 変換 |
-| `codd propagate --coherence` | lexicon + DESIGN.md を AI プロンプトに注入 (用語ぶれ・色値矛盾防止) |
-| Fixer Coherence-Mode | `run_fix(coherence_event=...)` で設計書修正を許可 (test 失敗修正フローは分離維持) |
-
-auto-fix が失敗した場合は自動で amber にダウングレードし、`docs/coherence/pending_hitl.md`
-に HITL レビュー待ちエントリとして記録。ntfy 通知はレート制限 (デフォルト 60 秒) で過剰通知を抑止。
-
-⚠️ **alpha 版**: Phase 4+ (Detector ↔ Applier 直接配管 / `codd fixup-drift` サブコマンド) は
-cmd_344 以降で実装予定。本リリースは中央ハブのアーキテクチャ確立段階。
-
----
-
-## 🆕 v1.15.0 — E2E test stub generator (`codd e2e-generate`)
-
-`screen-flow.md` + `requirements.md` から **Playwright / Cypress テストスタブ** を自動生成する `codd e2e-generate` を追加。`ScenarioExtractor` がルート / アクション / 受入条件を `docs/e2e/scenarios.md` に抽出し、`TestGenerator` が各 UserScenario を `.spec.ts` / `.cy.ts` に書き出す。**Generality Gate 適合** (フレームワーク非依存、Markdown / パス操作のみ)。
-
-```bash
-codd e2e-generate --framework playwright --output docs/e2e/tests
-codd e2e-generate --framework cypress    --output docs/e2e/tests
-```
-
-design token / lexicon ヒントを生成テストに自動注入し、Coherence Engine と連携する。
-
----
-
-## 🆕 v1.14.0 — Batch guard for `codd implement`
-
-`codd implement` で `--max-tasks N` (default: 30) と `--wave WAVE_ID` をサポート。大規模な implementation plan を安全に分割実行するための **preflight task count guard** で AI の暴走 fan-out を防止し、`--wave` / `--max-tasks` / `--task` の代替案を含む actionable error message を返す。
-
-```bash
-codd implement --max-tasks 30           # 30件超なら abort
-codd implement --wave wave_2_1          # wave_2_1 の tasks のみ実行
-```
-
-> v1.13.1 は `DesignTokenDriftLinker` の `project_root` Path 変換バグ修正パッチ。
-
----
-
-## 🆕 v1.13.0 — DESIGN.md統合 (Google Stitch OSS, W3C Design Tokens)
-
-**UI設計からコード生成まで完全なトレーサビリティを実現。**
-
-| 機能 | 説明 |
-|------|------|
-| `DesignMdExtractor` | DESIGN.md (W3C Design Tokens spec) を自動パース |
-| `KnowledgeFetcher` UI検出 | React/Vue/Svelte/Flutter 等を自動認識、DESIGN.md 採用を提案 |
-| `codd implement` 注入 | UIファイル生成時に DESIGN.md トークンを AI prompt に自動付与 |
-| `codd validate --design-tokens` | ハードコードされた #hex/px 値を検出して DESIGN.md 参照を推奨 |
-| `codd drift` design_token | UI実装のトークン参照と DESIGN.md 定義集合を比較 |
-| `codd verify --design-md` | `npx @google/design.md lint` を CoDD レポートに統合 |
-
-```yaml
-# DESIGN.md サンプル (プロジェクトルートに配置)
----
-version: "1.0"
-name: "My App"
-colors:
-  Primary: "#1A73E8"
-components:
-  Button.primary:
-    background: "{colors.Primary}"
----
-```
-
-仕様: [google-labs-code/design.md](https://github.com/google-labs-code/design.md)
-
----
-
-## 🆕 v1.12.0 — Meta-Design Context Layer (project_lexicon)
-
-CoDD now has a **meta-design context layer**: declare your project's vocabulary, naming conventions, and design principles once in `project_lexicon.yaml`, and every AI command (require / plan / generate / implement) automatically uses it.
-
-- 📖 `ProjectLexicon` — declare node vocabulary, naming conventions, design principles, failure modes
-- 🌐 `KnowledgeFetcher` — Web Search-first knowledge layer with 30-day cache; CoDD core has zero hardcoded framework knowledge
-- 🔍 `codd validate --lexicon` — detect naming convention violations in your lexicon
-- 🔌 Extractor registry — declare extractor classes by Python module path; `FileSystemRouteExtractor` is the first entry
-- 🧙 Lexicon wizard — `codd plan` auto-generates a draft `project_lexicon.yaml` when absent
-- 📋 `CoverageAuditor` — requirement gap detection with AUTO_ACCEPT / ASK / AUTO_REJECT 3-class rule
-- 🏷️ Provenance tracking — every lexicon entry carries `provenance`, `confidence`, and `fetched_at`
-
----
-
-## v1.11.0 — Filesystem-Routing Aware Drift Detection
-
-CoDD now understands filesystem-routing frameworks (Next.js, SvelteKit, Nuxt, Astro, Remix) and can detect URL drift between your design docs and actual implementation.
-
-- 📐 `FileSystemRouteExtractor` — endpoint nodes from directory structure
-- 🔗 `DocumentUrlLinker` — auto-link design doc URLs to endpoints
-- 🔍 `codd drift` — find URL gaps between design and implementation
-- 🎨 `codd extract --layer routes` — reverse-engineer screen-flow diagrams
-
-See [Filesystem Routing Adapter Recipes](#filesystem-routing-adapter-recipes) for setup.
-
----
-
-**v1.9.0** — `codd implement` now supports **multi-AI engine** (Claude stdout + Codex file-writing) and **automatic parallel execution** within phases via git worktree isolation. Phase milestone format (`#### M1.1`) supported. AI command timeout extended to 1 hour for heavy reasoning models. SWE-bench Verified: **73/73 = 100%** resolved.
-
----
-
-## Why CoDD?
-
-AI can generate specs. But **what happens when upstream changes?**
-
-Every spec-first tool stops at creation. CoDD starts there. When a requirement changes, code is updated, or a design assumption shifts, CoDD **automatically propagates the change downstream** — updating affected design docs, flagging stale artifacts, and producing an evidence trail.
-
-```
-Requirement changes → codd impact identifies 6 affected docs
-Code changes        → codd propagate updates downstream designs
-Design changes      → CEG graph traces all dependent artifacts
-```
-
-No other tool does this. spec-kit, Kiro, and cc-sdd create docs. **CoDD keeps them coherent.**
-
-## How It Works
-
-```
-Requirements (human)  →  Design docs (AI)  →  Code & tests (AI)
-         ↕                     ↕                     ↕
-     codd impact         codd propagate        codd extract
-    (what changed?)    (update downstream)   (reverse-engineer)
-```
-
-### The Three Layers
-
-```
-Harness (CLAUDE.md, Hooks, Skills)   ← Rules, guardrails, workflow
-  └─ CoDD (methodology)              ← Coherence across changes
-       └─ Design docs (docs/*.md)    ← Artifacts CoDD manages
-```
-
-CoDD is **harness-agnostic** — works with Claude Code, Copilot, Cursor, or any agent framework.
-
-## Core Principle: Derive, Don't Configure
-
-| Architecture | Derived test strategy | Config needed? |
-|---|---|---|
-| Next.js + Supabase | vitest + Playwright | None |
-| FastAPI + Python | pytest + httpx | None |
-| CLI tool in Go | go test | None |
-
-**Upstream determines downstream.** You define requirements and constraints. AI derives everything else.
-
-## Quick Start
-
-### Greenfield (new project)
+### 1. Install
 
 ```bash
 pip install codd-dev
-mkdir my-project && cd my-project && git init
-
-# Initialize — pass your requirements file, any format works
-codd init --project-name "my-project" --language "typescript" \
-  --requirements spec.txt
-
-# AI designs the document dependency graph
-codd plan --init
-
-# Generate design docs wave by wave
-waves=$(codd plan --waves)
-for wave in $(seq 1 $waves); do
-  codd generate --wave $wave
-done
-
-# Quality gate — catch AI laziness (TODOs, placeholders)
-codd validate
-
-# Generate code from design docs
-codd implement
-
-# Assemble code fragments into a buildable project
-codd assemble
+codd --version  # 1.34.0 or later
 ```
 
-### Brownfield (existing project)
-
-```bash
-codd extract              # Reverse-engineer design docs from code
-codd require              # Infer requirements from code (what was built and why)
-codd plan --init          # Generate wave_config from extracted docs
-codd scan                 # Build dependency graph
-codd impact               # Change impact analysis
-codd audit --skip-review  # Full change review: validate + impact + policy
-codd measure              # Project health score (0-100)
-```
-
-## Demos
-
-### Reproducible E2E Demo — 3 Propagation Patterns
-
-The following demo is pinned to commit [`d7d9f45`](https://github.com/yohey-w/codd-dev/commit/d7d9f45). You can reproduce the full cycle locally.
-
-**Setup:**
-```bash
-pip install codd-dev>=1.6.0
-mkdir demo && cd demo && git init
-cat > spec.txt << 'EOF'
-TaskFlow — Requirements
-- User authentication (email + Google OAuth)
-- Workspace management (teams, roles, invites)
-- Task CRUD with assignees, labels, due dates
-- Real-time updates (WebSocket)
-- File attachments (S3)
-- Notification system (in-app + email)
-EOF
-codd init --project-name "taskflow" --language "typescript" --requirements spec.txt
-```
-
-**Pattern 1 — Source → Doc** (spec → design docs):
-```bash
-codd plan --init
-for wave in $(seq 1 $(codd plan --waves)); do codd generate --wave $wave; done
-codd validate        # Expected: PASS, 0 errors
-codd scan            # Expected: 17 nodes, 30+ edges
-```
-
-**Pattern 2 — Doc → Doc** (requirement change → downstream update):
-```bash
-# Edit requirements: add "SSO (SAML 2.0)" to auth
-codd impact          # Expected: 6/7 design docs in Green/Amber band
-
-# Regenerate affected waves (propagate is for code→doc only)
-codd generate --wave 1 --force   # Re-derive acceptance criteria from updated requirements
-codd generate --wave 2 --force   # Re-derive system design from updated Wave 1
-# Repeat for each affected wave in dependency order
-```
-
-**Pattern 3 — Doc → Doc via CEG** (code change → design update):
-```bash
-# Modify source code in auth module
-codd propagate       # Expected: identifies auth-design, system-design as affected
-codd propagate --update  # AI updates affected design docs from code diff
-```
-
-**Expected output**: 20-line spec → 17 design artifacts (5,100+ lines) → downstream propagation keeps all docs coherent after changes. Pattern 3 (CEG-based propagation) is novel — no other tool traces code changes back through the dependency graph to update design documents.
-
-### Greenfield — Spec to Working App
-
-37 lines of spec → 6 design docs (1,353 lines) → 102 code files (6,445 lines) → TypeScript strict build passes. No interactive AI chat — the entire workflow is a shell script.
-
-Full walkthrough: [Harness as Code — A Guide to CoDD #1](https://zenn.dev/shio_shoppaize/articles/codd-greenfield-guide?locale=en)
-
-### Brownfield — Change Impact Analysis
-
-2 lines changed in requirements → `codd impact` identifies 6 out of 7 design docs affected. Green band: AI auto-updates. Amber band: human reviews. You know exactly what to fix before anything breaks.
-
-Deep dive: [CoDD deep-dive](https://zenn.dev/shio_shoppaize/articles/shogun-codd-coherence?locale=en)
-
-## Wave-Based Generation
-
-Design docs are generated in dependency order — each Wave depends on the previous:
-
-```
-Wave 1  Acceptance criteria + ADR       ← requirements only
-Wave 2  System design                   ← req + Wave 1
-Wave 3  DB design + API design          ← req + Wave 1-2
-Wave 4  UI/UX design                    ← req + Wave 1-3
-Wave 5  Implementation plan             ← all above
-```
-
-Verification runs bottom-up (V-Model):
-
-```
-Unit tests        ← verifies detailed design
-Integration       ← verifies system design
-E2E / System      ← verifies requirements + acceptance criteria
-```
-
-## Frontmatter = Single Source of Truth
-
-Dependencies are declared in Markdown frontmatter. No separate config files.
-
-```yaml
----
-codd:
-  node_id: "design:api-design"
-  modules: ["api", "auth"]        # ← links to source code modules
-  depends_on:
-    - id: "design:system-design"
-      relation: derives_from
-    - id: "req:my-project-requirements"
-      relation: implements
----
-```
-
-The `modules` field enables reverse traceability: when source code changes, `codd extract` identifies affected modules, and the `modules` field maps those modules back to the design docs that need updating.
-
-`codd/scan/` is a cache — regenerated on every `codd scan`.
-
-## Custom Node Prefixes
-
-By default, `node_id` values must use one of the built-in prefixes (`design:`, `req:`, `doc:`, `module:`, etc.). To use CoDD for non-software domains (knowledge bases, review documents, prompt management), add custom prefixes in `codd.yaml`:
+### 2. Add codd.yaml to your project
 
 ```yaml
 # codd.yaml
-prefixes:
-  - knowledge
-  - schema
-  - review
-  - prompt
+codd_required_version: ">=1.34.0"
+
+dag:
+  design_docs:
+    - "docs/design/**/*.md"
+  implementations:
+    - "src/**/*.{ts,tsx,py}"
+  tests:
+    - "tests/**/*.{spec,test}.{ts,tsx,py}"
+
+repair:
+  approval_mode: required   # automatic repair requires human approval
+  max_attempts: 10
+
+llm:
+  ai_command: "claude"      # any LLM CLI can be invoked (claude / codex / gemini, etc.)
 ```
 
-Custom prefixes are **merged with** built-in defaults — you don't need to re-list `design`, `req`, etc. Prefix names must be lowercase letters and underscores only (`[a-z_]+`).
-
-```yaml
-# Now valid in frontmatter:
-codd:
-  node_id: "knowledge:domain-model"
-```
-
-## AI Model Configuration
-
-CoDD calls an external AI CLI for document generation. The default is Claude Opus:
-
-```yaml
-# codd.yaml
-ai_command: "claude --print --model claude-opus-4-6"
-```
-
-### Per-Command Override
-
-Different commands can use different models. For example, use Opus for design doc generation but Codex for code implementation:
-
-```yaml
-ai_command: "claude --print --model claude-opus-4-6"   # global default
-ai_commands:
-  generate: "claude --print --model claude-opus-4-6"    # design doc generation
-  restore: "claude --print --model claude-opus-4-6"     # brownfield reconstruction
-  review: "claude --print --model claude-opus-4-6"      # quality evaluation
-  plan_init: "claude --print --model claude-sonnet-4-6" # wave_config planning
-  implement: "codex --print"                             # code generation
-```
-
-**Resolution priority**: CLI `--ai-cmd` flag > `ai_commands.{command}` > `ai_command` > built-in default (Opus).
-
-### Claude Code Context Interference
-
-When `claude --print` runs inside a project directory, it auto-discovers `CLAUDE.md` and loads project-level system prompts. These instructions can conflict with CoDD's generation prompts, causing format validation failures like:
-
-```
-Error: AI command returned unstructured summary for 'ADR: ...'; missing section headings
-```
-
-**Fix**: Use `--system-prompt` to override project context with a focused instruction:
-
-```yaml
-ai_command: "claude --print --model claude-opus-4-6 --system-prompt 'You are a technical document generator. Output only the requested Markdown document. Follow section heading instructions exactly.'"
-```
-
-> **Note**: `--bare` strips all context but also disables OAuth authentication. Use `--system-prompt` instead — it overrides `CLAUDE.md` while preserving auth.
-
-## Config Directory Discovery
-
-By default, `codd init` creates a `codd/` directory. If your project already has a `codd/` directory (e.g., it's your source code package), use `--config-dir`:
+### 3. Common commands
 
 ```bash
-codd init --config-dir .codd --project-name "my-project" --language "python"
+# Coherence verification (checks consistency across requirements, design, implementation, and tests)
+codd dag verify
+
+# Verification with auto-repair (when violations are found, an LLM generates and applies patches)
+codd dag verify --auto-repair --max-attempts 10
+
+# Confirm User Journey PASS in a real browser (browser control via CDP)
+codd dag run-journey login_to_dashboard --axis viewport=smartphone_se
+
+# Derive implementation steps from design docs (input to the implementation phase)
+codd implement run --task M1.2 --enable-typecheck-loop
 ```
 
-All other commands (`scan`, `impact`, `generate`, etc.) automatically discover whichever config directory exists — `codd/` first, then `.codd/`. No extra flags needed.
+### 4. Reading the output
 
-## Filesystem Routing Adapter Recipes
+`codd dag verify` runs 9 coherence checks:
 
-CoDD detects URL drift between your design documents and implementation
-using framework conventions declared in `codd.yaml`.
-These recipes cover the five major filesystem-routing frameworks.
+| Check | Role |
+|-------|------|
+| `node_completeness` | Confirms nodes declared in design docs (implementation/test files) exist as physical files |
+| `transitive_closure` | Confirms the dependency chain from requirements -> design -> implementation -> tests is closed |
+| `verification_test_runtime` | Confirms tests for implementations can run and pass |
+| `deployment_completeness` | Confirms the deployment chain (Dockerfile/compose/k8s) is complete |
+| `proof_break_authority` | Confirms critical journeys are not broken |
+| `screen_flow_edges` | Detects isolated nodes in the screen transition graph |
+| `screen_flow_completeness` | Confirms every screen is mapped to requirements |
+| `c8` | Detects uncommitted patches / dirty files |
+| `c9` (`environment_coverage`) | Confirms **target environment coverage** such as viewport, RBAC role, and locale |
 
-| Framework              | Base dir      | Page glob        | API glob                  | Dynamic segment       |
-|------------------------|---------------|------------------|---------------------------|-----------------------|
-| Next.js (App Router)   | `app/`        | `page.{tsx,jsx}` | `route.{ts,js}`           | `[param]` → `:param`  |
-| Next.js (Pages Router) | `pages/`      | `*.{tsx,jsx}`    | `api/**/*.{ts,js}`        | `[param]` → `:param`  |
-| SvelteKit              | `src/routes/` | `+page.svelte`   | `+server.{ts,js}`         | `[param]` → `:param`  |
-| Nuxt 3                 | `pages/`      | `*.vue`          | `server/api/**/*.{ts,js}` | `[param]` → `:param`  |
-| Astro                  | `src/pages/`  | `*.astro`        | `*.{ts,js}` (in pages)    | `[...slug]` → `:slug` |
-| Remix                  | `app/routes/` | `*.{tsx,jsx}`    | `*.{ts,js}`               | `$param` → `:param`   |
+When violations are found, the deploy gate is blocked. With `--auto-repair`, CoDD enters a loop that asks an LLM to generate patches, applies them, and verifies again.
 
-### Next.js (App Router)
+---
+
+## Typical Use Cases
+
+### Use Case 1: Automating requirements -> design -> implementation
+
+Write "functional requirements + constraints" in `docs/requirements/*.md`, then run `codd implement run`:
+
+1. An LLM dynamically derives ImplStep sequences from the requirements (Layer 1)
+2. Best-practice gaps are filled in (Layer 2, such as logout, Remember Me, and session timeout for login)
+3. After user approval through a HITL gate, implementation is generated into `src/**`
+4. If a type checker such as `tsc` fails during generation, CoDD enters the auto-repair loop
+
+The user experience is: **write only functional requirements + constraints, then let the rest run automatically**.
+
+### Use Case 2: Auto-Repair (`codd verify --auto-repair`)
+
+Run `codd dag verify --auto-repair --max-attempts 10` in CI:
+
+1. 9 coherence checks are executed
+2. Violations are classified as **repairable (in-task) / pre-existing (baseline) / unrepairable** by a Hybrid Classifier (git diff + LLM)
+3. Among repairable violations, the most upstream one in the DAG is selected and an LLM generates a patch
+4. The patch goes through dry-run validation, then is applied and verified again
+5. If all violations are resolved within `max_attempts`, the status is `SUCCESS`; if some are repaired, `PARTIAL_SUCCESS`; if only unrepairable items remain, `REPAIR_FAILED`
+
+Even in `PARTIAL_SUCCESS`, repaired patches are kept and remaining violations are listed transparently in the report.
+
+### Use Case 3: User Journey Coherence (`codd dag run-journey`)
+
+Declare a user journey in the frontmatter of `docs/design/auth_design.md`:
 
 ```yaml
-filesystem_routes:
-  - base_dir: app/
-    page_pattern: "page.{tsx,jsx,ts,js}"
-    api_pattern: "route.{ts,js}"
-    url_template: "/{relative_dir}"
-    dynamic_segment: { from: "\\[(.+)\\]", to: ":$1" }
-    ignore_segment: ["\\(.*\\)", "@.*"]
-    base_url: ""
-```
-
-### Next.js (Pages Router)
-
-```yaml
-filesystem_routes:
-  - base_dir: pages/
-    page_pattern: "*.{tsx,jsx,ts,js}"
-    api_pattern: ""
-    url_template: "/{relative_dir}/{stem}"
-    dynamic_segment: { from: "\\[(.+)\\]", to: ":$1" }
-    ignore_segment: ["^_.*"]
-    base_url: ""
-  - base_dir: pages/api/
-    page_pattern: ""
-    api_pattern: "*.{ts,js}"
-    url_template: "/api/{relative_dir}/{stem}"
-    dynamic_segment: { from: "\\[(.+)\\]", to: ":$1" }
-    ignore_segment: []
-    base_url: ""
-```
-
-### SvelteKit
-
-```yaml
-filesystem_routes:
-  - base_dir: src/routes/
-    page_pattern: "+page.svelte"
-    api_pattern: "+server.{ts,js}"
-    url_template: "/{relative_dir}"
-    dynamic_segment: { from: "\\[(.+)\\]", to: ":$1" }
-    ignore_segment: ["\\(.*\\)"]
-    base_url: ""
-```
-
-### Nuxt 3
-
-```yaml
-filesystem_routes:
-  - base_dir: pages/
-    page_pattern: "*.vue"
-    api_pattern: ""
-    url_template: "/{relative_dir}/{stem}"
-    dynamic_segment: { from: "\\[(.+)\\]", to: ":$1" }
-    ignore_segment: []
-    base_url: ""
-  - base_dir: server/api/
-    page_pattern: ""
-    api_pattern: "*.{ts,js}"
-    url_template: "/api/{relative_dir}/{stem}"
-    dynamic_segment: { from: "\\[(.+)\\]", to: ":$1" }
-    ignore_segment: []
-    base_url: ""
-```
-
-### Astro
-
-```yaml
-filesystem_routes:
-  - base_dir: src/pages/
-    page_pattern: "*.astro"
-    api_pattern: "*.{ts,js}"
-    url_template: "/{relative_dir}/{stem}"
-    dynamic_segment: { from: "\\[\\.\\.\\.(\\w+)\\]", to: ":$1" }
-    ignore_segment: []
-    base_url: ""
-```
-
-### Remix
-
-```yaml
-filesystem_routes:
-  - base_dir: app/routes/
-    page_pattern: "*.{tsx,jsx}"
-    api_pattern: "*.{ts,js}"
-    url_template: "/{segments}"
-    dynamic_segment: { from: "\\$(\\w+)", to: ":$1" }
-    ignore_segment: ["^_.*"]
-    base_url: ""
-```
-
-### Enable URL Drift Detection
-
-Add to `codd.yaml` to automatically link design doc URLs to endpoints:
-
-```yaml
-document_url_linking:
-  enabled: true
-  applies_to: [design, requirement]
-  url_pattern: "(?:^|[\\s`(\\[])(/[a-z0-9][a-z0-9/\\-:_\\[\\]]*)"
-  edge_type: references
-```
-
-Then run:
-
-```bash
-codd drift          # detect URL drift between design docs and implementation
-codd drift --format json  # machine-readable output
-codd extract --layer routes --format mermaid  # generate screen-flow diagram
-```
-
-## Brownfield? Start Here
-
-Already have a codebase? CoDD provides a full brownfield workflow — from code extraction to design doc reconstruction.
-
-Full walkthrough: [Harness as Code — A Guide to CoDD #2 Brownfield](https://zenn.dev/shio_shoppaize/articles/shogun-codd-brownfield?locale=en)
-
-### AI-Powered Extraction (--ai)
-
-> **Note on presets**: `codd extract --ai` ships with a **baseline** extraction prompt. The extraction quality in published benchmarks (F1 0.953+) was achieved with a tuned preset and internal evaluation dataset — not the public baseline. The baseline uses the same workflow and output format, but results will vary depending on your codebase and prompt. Use `--prompt-file` to supply your own tuned prompt.
-
-```bash
-codd extract --ai                        # Uses built-in baseline preset
-codd extract --ai --prompt-file my.md    # Uses your custom prompt
-```
-
-### Step 1: Extract structure from code
-
-`codd extract` reverse-engineers design documents from your source code. No AI required — pure static analysis.
-
-```bash
-cd existing-project
-codd extract
-```
-
-```
-Extracted: 13 modules from 45 files (12,340 lines)
-Output: codd/extracted/
-  system-context.md     # Module map + dependency graph
-  modules/auth.md       # Per-module design doc
-  modules/api.md
-  modules/db.md
-  ...
-```
-
-### Step 2: Generate wave_config from extracted docs
-
-`codd plan --init` automatically detects extracted docs and generates a wave_config — no requirement docs needed.
-
-```bash
-codd plan --init    # Detects codd/extracted/, builds brownfield wave_config
-```
-
-Each artifact in the generated wave_config includes a `modules` field linking it to source code modules — enabling reverse traceability from code changes back to design docs.
-
-### Step 3: Restore design documents
-
-`codd restore` reconstructs design documents from extracted facts. Unlike `codd generate` (which creates docs from requirements), `restore` asks *"what IS the current design?"* — reconstructing intent from code structure.
-
-```bash
-codd restore --wave 2   # Reconstruct system design from extracted facts
-codd restore --wave 3   # Reconstruct DB/API design
-```
-
-### Step 4: Build the graph
-
-```bash
-codd scan
-codd impact
-```
-
-**Philosophy**: In V-Model, intent lives only in requirements. Architecture, design, and tests are structural facts — extractable from code. `codd extract` gets the structure; `codd restore` reconstructs the design; you add the "why" later.
-
-### Greenfield vs Brownfield
-
-| | Greenfield | Brownfield |
-|--|-----------|-----------|
-| Starting point | Requirements (human-written) | Existing codebase |
-| Planning | `codd plan --init` (from requirements) | `codd plan --init` (from extracted docs) |
-| Doc generation | `codd generate` (forward: requirements → design) | `codd restore` (backward: code facts → design) |
-| Traceability | `modules` field links docs → code | `modules` field links docs → code |
-| Modification | `codd propagate` (code → affected docs → optional AI update) | Same flow |
-
-## Commands
-
-| Command | Status | Description |
-|---------|--------|-------------|
-| `codd init` | **Stable** | Initialize CoDD in any project (`--config-dir .codd` for projects where `codd/` exists) |
-| `codd scan` | **Stable** | Build dependency graph from frontmatter |
-| `codd impact` | **Stable** | Change impact analysis (Green / Amber / Gray) |
-| `codd validate` | **Alpha** | Frontmatter integrity & graph consistency check |
-| `codd generate` | Experimental | Generate design docs in Wave order (greenfield) |
-| `codd restore` | Experimental | Reconstruct design docs from extracted facts (brownfield) |
-| `codd plan` | Experimental | Wave execution status (`--init` supports brownfield fallback) |
-| `codd verify` | Experimental (Pro) | V-Model verification |
-| `codd implement` | Experimental | Design-to-code generation |
-| `codd propagate` | **Alpha** | Propagate code/doc changes downstream to affected design docs |
-| `codd review` | Experimental (Pro) | AI-powered artifact quality evaluation (LLM-as-Judge) |
-| `codd extract` | **Alpha** | Reverse-engineer design docs from existing code |
-| `codd require` | **Alpha** | Infer requirements from existing codebase (brownfield) |
-| `codd audit` | **Alpha** (Pro) | Consolidated change review pack (validate + impact + policy + review) |
-| `codd policy` | **Alpha** | Enterprise policy checker (forbidden/required patterns in source code) |
-| `codd measure` | **Alpha** | Project health metrics (graph, coverage, quality, health score 0-100) |
-| `codd mcp-server` | **Alpha** | MCP server for AI tool integration (stdio, zero dependencies) |
-| `codd fix` | **Alpha** | Auto-fix test/build failures with diagnostic reasoning and session state |
-
-## SWE-bench Verified
-
-CoDD's `fix` command with diagnostic reasoning achieves **73/73 = 100%** on a curated subset of [SWE-bench Verified](https://www.swebench.com/verified.html). The diagnostic step forces root cause analysis before patching, and session state prevents repeating failed approaches across retries.
-
-| Metric | Result |
-|--------|--------|
-| Instances | 73 (curated from SWE-bench Verified) |
-| Resolved | **73 (100%)** |
-| Key feature | Diagnostic reasoning + session state persistence |
-
-Details: [Zenn: CoDD SWE-bench Guide](https://zenn.dev/shio_shoppaize/articles/codd-swebench-pilot?locale=en)
-
-## OSS / Pro Split
-
-CoDD v1.6.0 introduced a clean OSS/Pro boundary via a bridge pattern.
-
-**OSS (MIT, free)** — everything you need to keep docs coherent:
-
-`init` · `scan` · `impact` · `generate` · `restore` · `propagate` · `extract` · `require` · `plan` · `validate` · `measure` · `policy` · `fix` · `mcp-server`
-
-**Pro (private, paid)** — enterprise review and verification:
-
-`review` · `verify` · `audit` · `risk`
-
-```bash
-# OSS only
-pip install codd-dev
-
-# Add Pro extensions
-pip install "codd-pro @ git+ssh://git@github.com/yohey-w/codd-pro.git"
-```
-
-When `codd-pro` is installed, Pro implementations automatically override OSS fallbacks via entry-points plugin discovery. When it's not installed, Pro commands show a migration message and exit gracefully. No configuration needed.
-
-## CI Integration (GitHub Action)
-
-Run CoDD audit on every pull request. The action posts a comment with verdict (APPROVE / CONDITIONAL / REJECT), validation results, policy violations, and impact analysis.
-
-### Quick Setup
-
-Add `.github/workflows/codd.yml` to your project:
-
-```yaml
-name: CoDD Audit
-on:
-  pull_request:
-    branches: [main]
-
-permissions:
-  contents: read
-  pull-requests: write
-
-jobs:
-  audit:
-    runs-on: ubuntu-latest
+user_journeys:
+  - name: login_to_dashboard
+    criticality: critical
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: yohey-w/codd-dev@main
-        with:
-          diff-target: origin/${{ github.base_ref }}
-          skip-review: "true"  # Set to "false" to enable AI review
+      - { action: navigate, target: "/login" }
+      - { action: fill, selector: "input[type=email]", value: "user@example.com" }
+      - { action: click, selector: "button[type=submit]" }
+      - { action: expect_url, value: "/dashboard" }
 ```
 
-### Action Inputs
+With `codd dag run-journey login_to_dashboard --axis viewport=smartphone_se`:
 
-| Input | Default | Description |
-|-------|---------|-------------|
-| `diff-target` | `origin/main` | Git ref to diff against |
-| `skip-review` | `true` | Skip AI review phase (faster, no AI cost) |
-| `python-version` | `3.12` | Python version |
-| `codd-version` | latest | Specific version (e.g., `>=1.3.0`) |
-| `post-comment` | `true` | Post results as PR comment |
+- `viewport=smartphone_se` (375x667), declared in `project_lexicon.yaml`, is injected into runtime through CDP
+- The journey runs in a real browser (Edge / Chrome)
+- If it fails, C9 `environment_coverage` in `codd dag verify` blocks the deploy gate
 
-### Action Outputs
+This structurally prevents incidents such as smartphone-only navigation disappearing unnoticed.
 
-| Output | Description |
-|--------|-------------|
-| `verdict` | `APPROVE`, `CONDITIONAL`, or `REJECT` |
-| `risk-level` | `LOW`, `MEDIUM`, or `HIGH` |
-| `report-json` | Path to the JSON audit report |
+---
 
-### Enterprise Policies
+## v1.34.0 Key Features
 
-Define source code policies in your `codd.yaml`:
+| Feature | Role |
+|---------|------|
+| **DAG Completeness** (C1-C8) | 9 coherence checks across requirements, design, implementation, tests, and deployment |
+| **Coverage Axis Layer** (C9) | Verifies **target environment coverage** such as viewport, RBAC role, and locale through a unified abstraction supporting 16+ axes |
+| **LLM Auto-Repair (RepairLoop)** | Violation detection -> LLM patch generation -> apply -> verify again, attempting full resolution within `max_attempts` |
+| **Hybrid Classifier** | Classifies violations as repairable / pre_existing / unrepairable using git diff (Stage 1) + LLM judgment (Stage 2) |
+| **Primary Picker** | Prioritizes the most upstream violation in the DAG as the likely root cause among multiple violations |
+| **PARTIAL_SUCCESS policy** | Returns PARTIAL_SUCCESS when applied_patches, pre_existing, or unrepairable items exist, avoiding release blockage by transparent non-current-task issues |
+| **BestPracticeAugmenter** | Dynamically fills in best practices that are not explicitly written in design docs, such as password reset |
+| **ImplStepDeriver (2-layer)** | Dynamically expands design docs into ImplStep sequences and infers `required_axes` in Layer 2 |
+| **Typecheck Repair Loop** | Runs an auto-repair loop when a type checker such as `tsc --noEmit` fails during implementation |
+| **`codd version --check --strict`** | Detects differences between the project's required CoDD version and the installed version |
 
-```yaml
-policies:
-  - id: SEC-001
-    description: "No hardcoded passwords"
-    severity: CRITICAL
-    kind: forbidden
-    pattern: 'password\s*=\s*[''"]'
-    glob: "*.py"
+See [CHANGELOG.md](CHANGELOG.md) for details.
 
-  - id: LOG-001
-    description: "All modules must import logging"
-    severity: WARNING
-    kind: required
-    pattern: "import logging"
-    glob: "*.py"
+---
+
+## Case Study - osato-lms (LMS Web App)
+
+Result of running `codd verify --auto-repair --max-attempts 10` on the LMS project osato-lms (Next.js + Prisma + PostgreSQL):
+
+```text
+status:                   PARTIAL_SUCCESS
+attempts:                 4
+applied_patches:          4
+pre_existing_violations:  1
+unrepairable_violations:  2
+remaining_violations:     3 (skipped + reported)
+smoke proof:              6 checks PASS
+CoDD core changes:        0 lines
 ```
 
-The policy checker runs as part of `codd audit` and independently via `codd policy`. Critical violations cause REJECT; warnings cause CONDITIONAL.
+Repaired files:
 
-## MCP Server
+- `tests/e2e/environment-coverage.spec.ts`
+- `tests/e2e/login.spec.ts`
 
-CoDD exposes its tools via the [Model Context Protocol](https://modelcontextprotocol.io/) for direct AI tool integration. Zero external dependencies — works with any MCP-compatible client.
+Skipped violations (explicitly reported as outside CoDD's responsibility):
 
-```bash
-codd mcp-server --project /path/to/your/project
-```
+- pre_existing: deployment_completeness chain
+- unrepairable: Dockerfile dry-run patch validation
+- unrepairable: Vitest matcher runtime issue
 
-### Claude Code Configuration
+C9 `environment_coverage` verified all axis x variant coverage for viewport (smartphone_se / desktop_1920) and RBAC role (central_admin / tenant_admin / learner), and reached PASS.
 
-Add to `~/.claude/claude_code_config.json`:
+---
 
-```json
-{
-  "mcpServers": {
-    "codd": {
-      "command": "codd",
-      "args": ["mcp-server", "--project", "/path/to/your/project"]
-    }
-  }
-}
-```
+## Architecture - 4-Release Evolution
 
-### Available MCP Tools
+| Release | Milestone |
+|---------|-----------|
+| v1.31.0 | Inner 100% (internal coherence) - eliminated manual type fixes with the typecheck repair loop |
+| v1.32.0 | Outer 100% (target environment coverage) - absorbed viewport/RBAC/locale and related axes through a unified abstraction |
+| v1.33.0 | Caveat-resolution path proven - real CDP run-journey + LLM auto-repair attempt passed |
+| **v1.34.0** | **Full pipeline proven** - auto-repair reached PARTIAL_SUCCESS on a real project |
 
-| Tool | Description |
-|------|-------------|
-| `codd_validate` | Check frontmatter integrity and graph consistency |
-| `codd_impact` | Analyze change impact for a given node or file |
-| `codd_policy` | Check source code against enterprise policy rules |
-| `codd_audit` | Consolidated change review (validate + impact + policy) |
-| `codd_scan` | Build dependency graph from design documents |
-| `codd_measure` | Project health metrics (graph, coverage, quality, health score) |
+See [CHANGELOG.md](CHANGELOG.md) for each release.
 
-## Claude Code Integration
+---
 
-CoDD ships with slash-command Skills for Claude Code. Instead of running CLI commands yourself, use Skills — Claude reads the project context and runs the right command with the right flags.
+## Generality Gate (Absolute Generality Preservation)
 
-### Skills Demo — Same TaskFlow App, Zero CLI
+The following hardcoding is **forbidden** in CoDD core code:
 
-```
-You:  /codd-init
-      → Claude: codd init --project-name "taskflow" --language "typescript" \
-                  --requirements spec.txt
+- Specific stack names (Next.js / Django / Rails / FastAPI, etc.)
+- Specific framework / library literals
+- Specific domains (Web / Mobile / Desktop / CLI / Backend / Embedded)
+- Specific viewport values (375 / 1920, etc.) or device names (iPhone / Android, etc.)
 
-You:  /codd-generate
-      → Claude: codd generate --wave 2 --path .
-      → Claude reads every generated doc, checks scope, validates frontmatter
-      → "Wave 2の設計書を確認しました。Wave 3に進みますか？"
+All such knowledge is confined to **`project_lexicon.yaml` (project-specific)**. CoDD handles it only as generic violation objects.
 
-You:  yes
+When an LLM proposes a stack-specific optimal patch, that judgment is delegated to **the LLM's knowledge**. CoDD core does not decide it, which prevents overfitting.
 
-You:  /codd-generate
-      → Claude: codd generate --wave 3 --path .
-
-You:  /codd-scan
-      → Claude: codd scan --path .
-      → Reports: "7 documents, 15 edges. No warnings."
-
-You:  (edit requirements — add SSO + audit logging)
-
-You:  /codd-impact
-      → Claude: codd impact --path .
-      → Green Band: auto-updates system-design, api-design, db-design, auth-design
-      → Amber Band: "test-strategy is affected. Update it?"
-
-You:  (modify source code — implement the SSO feature)
-
-You:  /codd-propagate
-      → Claude: codd propagate --path .
-      → "3 files changed in auth module. 2 design docs affected:
-         design:system-design, design:auth-detail"
-      → "Run with --update to update these docs?"
-
-You:  yes
-      → Claude: codd propagate --path . --update
-      → Reviews updated docs, confirms changes are accurate
-```
-
-**Key difference**: Skills add human-in-the-loop gates. `/codd-generate` pauses between waves for approval. `/codd-impact` follows the Green/Amber/Gray protocol — auto-updating safe changes, asking before risky ones.
-
-### Hook Integration — Set It Once, Never Think Again
-
-CoDD ships copyable hook recipes in `codd/hooks/recipes/` so Claude, Codex, and Git can all trigger the same change-driven propagation path:
-`codd propagate-from --files <changed-file>`.
-
-#### Claude PostToolUse
-
-Use `codd/hooks/recipes/claude_settings_example.json` as the starting point for `.claude/settings.json`. It listens for Edit / Write / MultiEdit and extracts changed files from `TOOL_INPUT` before calling `propagate-from`.
-
-```json
-{
-  "hooks": {
-    "PostToolUse": [{
-      "matcher": "Edit|Write|MultiEdit",
-      "hooks": [{
-        "type": "command",
-        "command": "python -m codd propagate-from --files <changed-file> --source editor_hook --editor claude"
-      }]
-    }]
-  }
-}
-```
-
-#### Codex Post-Edit
-
-Use `codd/hooks/recipes/codex_hook.sh` when your Codex wrapper can pass edited files through `CODEX_EDITED_FILES`:
-
-```bash
-export CODEX_EDITED_FILES="src/app.ts,docs/design/api.md"
-bash codd/hooks/recipes/codex_hook.sh
-```
-
-#### Git Hooks
-
-Use the git recipes as a final catch for manual edits and non-editor workflows:
-
-```bash
-cp codd/hooks/recipes/git_pre_commit.sh .git/hooks/pre-commit
-cp codd/hooks/recipes/git_post_commit.sh .git/hooks/post-commit
-chmod +x .git/hooks/pre-commit .git/hooks/post-commit
-```
-
-The pre-commit hook runs `propagate-from` in `--dry-run` mode against staged files. The post-commit hook runs propagation against the committed file set.
-
-With hooks active, your entire workflow becomes: **edit files normally, and CoDD propagates the change from the files that actually changed.** The graph maintenance is invisible.
-
-### Available Skills
-
-| Skill | What it does |
-|-------|-------------|
-| `/codd-init` | Initialize + import requirements |
-| `/codd-generate` | Generate design docs wave-by-wave with HITL gates (greenfield) |
-| `/codd-restore` | Reconstruct design docs from extracted code facts (brownfield) |
-| `/codd-scan` | Rebuild dependency graph |
-| `/codd-impact` | Change impact analysis with Green/Amber/Gray protocol |
-| `/codd-validate` | Frontmatter & dependency consistency check |
-| `/codd-propagate` | Reverse-propagate source code changes to design docs |
-| `/codd-review` | AI quality review with PASS/FAIL verdict and feedback |
-
-See [docs/claude-code-setup.md](docs/claude-code-setup.md) for complete setup.
-
-## Autonomous Quality Loop
-
-`codd review` evaluates artifacts using AI (LLM-as-Judge), and `--feedback` feeds results back into generation. Together they enable a fully autonomous quality loop:
-
-```bash
-# Generate → Review → Regenerate with feedback until PASS
-codd generate --wave 2 --force
-feedback=$(codd review --path . --json | jq -r '.results[0].feedback')
-verdict=$(codd review --path . --json | jq -r '.results[0].verdict')
-
-while [ "$verdict" = "FAIL" ]; do
-  codd generate --wave 2 --force --feedback "$feedback"
-  result=$(codd review --path . --json)
-  verdict=$(echo "$result" | jq -r '.results[0].verdict')
-  feedback=$(echo "$result" | jq -r '.results[0].feedback')
-done
-```
-
-Review criteria are type-specific:
-
-| Doc Type | Criteria |
-|----------|----------|
-| Requirement | Completeness, consistency, testability, ambiguity |
-| Design | Architecture soundness, API quality, security, upstream consistency |
-| Detailed Design | Implementation clarity, data model, error handling, interface contracts |
-| Test | Coverage, edge cases, independence, traceability |
-
-**Scoring**: 80+ = PASS. CRITICAL issues auto-cap at 59. Exit code 1 on FAIL — loop-friendly.
-
-**Model allocation**: Use Opus for review (`ai_commands.review`), Codex for implementation (`ai_commands.implement`). The `ai_commands` config makes this a one-line change.
-
-## How CoDD Differs from Other Spec-Driven Tools
-
-All major spec-driven tools focus on **creating** design documents. None address what happens when those documents **change**. CoDD fills that gap with a dependency graph, impact analysis, and a band-based update protocol.
-
-| | **spec-kit** (GitHub) | **Kiro** (AWS) | **cc-sdd** (gotalab) | **CoDD** |
-|--|---|---|---|---|
-| Focus | Spec creation (req -> design -> tasks -> code) | Agentic IDE with native SDD pipeline | Kiro-style SDD for Claude Code | **Post-creation coherence maintenance** |
-| Stars | 83.7k | N/A (proprietary IDE) | 3k | -- |
-| Change propagation | No | No | No | **`codd impact` + dependency graph** |
-| Impact analysis | No | No | No | **Green / Amber / Gray bands** |
-| Spec notation | Markdown + 40 extensions | EARS notation | Quality gates + git worktree | Frontmatter `depends_on` |
-| Harness lock-in | GitHub Copilot | Kiro IDE | Claude Code | **Any agent / IDE** |
-
-In short: spec-kit, Kiro, and cc-sdd answer *"how do I create specs?"* CoDD answers *"when something changes upstream, how do I automatically update everything downstream?"*
-
-## Comparison
-
-|  | Spec Kit | OpenSpec | **CoDD** |
-|--|----------|---------|----------|
-| Spec-first generation | Yes | Yes | Yes |
-| **Change propagation** | No | No | **Dependency graph + impact analysis** |
-| **Derive test strategy** | No | No | **Automatic from architecture** |
-| **V-Model verification** | No | No | **Unit → Integration → E2E** |
-| **Impact analysis** | No | No | **`codd impact`** |
-| Harness-agnostic | Copilot focused | Multi-agent | **Any harness** |
-
-## Real-World Usage
-
-Battle-tested on a production web app — 18 design docs connected by a dependency graph. All docs, code, and tests generated by AI following CoDD. When requirements changed mid-project, `codd impact` identified affected artifacts and AI fixed them automatically.
-
-```
-docs/
-├── requirements/       # What to build (human input — plain text)
-├── design/             # System design, API, DB, UI (AI-generated)
-├── detailed_design/    # Module-level specs (AI-generated)
-├── governance/         # ADRs (AI-generated)
-├── plan/               # Implementation plan
-├── test/               # Acceptance criteria, test strategy
-├── operations/         # Runbooks
-└── infra/              # Infrastructure design
-```
-
-### CoDD Manages Its Own Development
-
-CoDD dogfoods itself. The `.codd/` directory contains CoDD's own config, and `codd extract` reverse-engineers design docs from its own source code. The full V-Model lifecycle runs on itself:
-
-```bash
-codd init --config-dir .codd --project-name "codd-dev" --language "python"
-codd extract          # 15 modules → design docs with dependency frontmatter
-codd scan             # 49 nodes, 83 edges
-codd verify           # mypy + pytest (434 tests pass)
-```
-
-If CoDD can't manage itself, it shouldn't manage your project.
-
-## Roadmap
-
-- [ ] Semantic dependency types (`requires`, `affects`, `verifies`, `implements`)
-- [x] `codd extract` — reverse-generate design docs from existing codebases (brownfield support)
-- [x] `codd restore` — reconstruct design docs from extracted facts (brownfield doc generation)
-- [x] `codd plan --init` brownfield fallback — generate wave_config from extracted docs
-- [x] `modules` field — design doc ↔ source code traceability
-- [x] Per-command AI model configuration (`ai_commands` in codd.yaml)
-- [x] `codd propagate` — reverse-propagate source code changes to design documents
-- [x] `codd review` — AI-powered quality evaluation with review-driven regeneration loop
-- [x] `--feedback` flag — feed review results back into generate/restore/propagate
-- [x] `codd verify` — language-agnostic verification (Python: mypy + pytest, TypeScript: tsc + jest)
-- [x] `codd require` — infer requirements from existing codebase with confidence tags
-- [x] `codd audit` — consolidated change review pack (validate + impact + policy + review)
-- [x] `codd policy` — enterprise policy checker (forbidden/required patterns)
-- [x] `codd measure` — project health metrics (graph, coverage, quality, score 0-100)
-- [x] GitHub Action — CI integration for PR audit with auto-commenting
-- [x] MCP Server — stdio JSON-RPC server for AI tool integration
-- [x] Plugin system — extensible require prompts (tags, evidence format, output sections)
-- [ ] Multi-harness integration examples (Claude Code, Copilot, Cursor)
-- [ ] VS Code extension for impact visualization
-
-## Articles
-
-- [dev.to: Harness as Code — Treating AI Workflows Like Infrastructure](https://dev.to/yohey-w/harness-as-code-treating-ai-workflows-like-infrastructure-27ni)
-- [dev.to: What Happens After "Spec First"](https://dev.to/yohey-w/codd-coherence-driven-development-what-happens-after-spec-first-514f)
-- [Zenn: Harness as Code — A Guide to CoDD #1 spec → design → code](https://zenn.dev/shio_shoppaize/articles/codd-greenfield-guide?locale=en)
-- [Zenn: Harness as Code — A Guide to CoDD #2 Brownfield](https://zenn.dev/shio_shoppaize/articles/shogun-codd-brownfield?locale=en)
-- [Zenn: Harness as Code — A Guide to CoDD #3 Bug Fixing with CoDD extract (SWE-bench)](https://zenn.dev/shio_shoppaize/articles/codd-swebench-pilot?locale=en)
-- [Zenn: CoDD deep-dive](https://zenn.dev/shio_shoppaize/articles/shogun-codd-coherence?locale=en)
-
-## Sponsors
-
-<a href="https://github.com/sponsors/yohey-w">
-  <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?style=for-the-badge&logo=github-sponsors" alt="Sponsor">
-</a>
-
-Your sponsorship keeps CoDD free and funds continued development. See [sponsor tiers](https://github.com/sponsors/yohey-w).
+---
 
 ## License
 
-MIT
+MIT License - see [LICENSE](LICENSE).
+
+## Links
+
+- [CHANGELOG.md](CHANGELOG.md) - full release notes
+- [GitHub Sponsors](https://github.com/sponsors/yohey-w) - support development
+- [Issues](https://github.com/yohey-w/codd-dev/issues) - bug reports / feature requests
+
+---
+
+> When code changes, CoDD traces the impact, detects violations, and produces evidence for merge decisions.

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,6 +1,5 @@
 <p align="center">
-  <strong>CoDD — Coherence-Driven Development（一貫性駆動開発）</strong><br>
-  <em>AI支援開発における変更管理のエビデンスエンジン。</em>
+  <strong>CoDD — Coherence-Driven Development（一貫性駆動開発）</strong>
 </p>
 
 <p align="center">
@@ -16,809 +15,220 @@
 
 ---
 
-> *コードが変わったとき、CoDDは影響範囲を追跡し、違反を検出し、マージ判断のためのエビデンスを生成する。*
+## 機能要件と制約だけ書けば、コードは自動で書ける。
 
-```
-pip install codd-dev
-```
+CoDD は **要件 → 設計 → 実装 → テスト** をひとつの DAG として扱い、各ノードの一貫性 (coherence) を機械検証して、不整合があれば LLM が自動で修復する開発エンジンである。
 
-## 🆕 v1.16.0-alpha — Coherence Engine（整合性駆動の中央ハブ）
-
-**drift / validate / propagate / fix を `DriftEvent` 統一フォーマットで結ぶ中央ハブ。**
-
-| コンポーネント | 役割 |
-|----------------|------|
-| `DriftEvent` | source/target/change_type/payload/severity/fix_strategy/kind を持つ統一イベント型 |
-| `EventBus` | in-process pub/sub。Detector が publish、Orchestrator が subscribe |
-| `Orchestrator` | severity ルーティング: `red` → auto-fix / `amber` → pending HITL / `green` → log |
-| `coherence_adapters` | drift / validate / design-token violation 出力 → DriftEvent 変換 |
-| `codd propagate --coherence` | lexicon + DESIGN.md を AI プロンプトに注入（用語ぶれ・色値矛盾の自動防止） |
-| Fixer Coherence-Mode | `run_fix(coherence_event=...)` で設計書修正を許可（test 失敗修正フローは分離維持） |
-
-auto-fix が失敗した場合は自動で amber にダウングレードし、`docs/coherence/pending_hitl.md` に HITL レビュー待ちエントリとして記録。ntfy 通知はレート制限（デフォルト 60 秒）で過剰通知を抑止。**既存CLI (`codd drift` / `validate` / `propagate` / `fix`) は100%後方互換**、`--coherence` を渡さない限り従来挙動を維持。
-
-⚠️ **alpha 版**: Phase 4+（Detector ↔ Applier の直接配管 / `codd fixup-drift` サブコマンド）は次バージョンで実装予定。本リリースは中央ハブのアーキテクチャ確立段階。
-
----
-
-## 🆕 v1.14.0 — `codd implement` の Batch guard
-
-`codd implement` で `--max-tasks N`（デフォルト30）と `--wave WAVE_ID` をサポート。大規模な implementation plan を安全に分割実行するための **preflight task count guard** で AI の暴走 fan-out を防止し、`--wave` / `--max-tasks` / `--task` の代替案を含む actionable error message を返す。
-
-```bash
-codd implement --max-tasks 30           # 30件超なら abort
-codd implement --wave wave_2_1          # wave_2_1 の tasks のみ実行
-```
-
-> v1.13.1 は `DesignTokenDriftLinker` の `project_root` Path 変換バグ修正パッチ。
-
----
-
-## 🆕 v1.13.0 — DESIGN.md統合（Google Stitch OSS, W3C Design Tokens）
-
-**UI設計からコード生成まで完全なトレーサビリティを実現。**
-
-| 機能 | 説明 |
-|------|------|
-| `DesignMdExtractor` | DESIGN.md（W3C Design Tokens spec）を自動パース |
-| `KnowledgeFetcher` UI検出 | React/Vue/Svelte/Flutter 等を自動認識し DESIGN.md 採用を提案 |
-| `codd implement` 注入 | UIファイル生成時に DESIGN.md トークンを AI prompt に自動付与 |
-| `codd validate --design-tokens` | ハードコードされた #hex/px 値を検出し DESIGN.md 参照を推奨 |
-| `codd drift` design_token | UI実装のトークン参照と DESIGN.md 定義集合を比較 |
-| `codd verify --design-md` | `npx @google/design.md lint` を CoDD レポートに統合 |
-
-```yaml
-# DESIGN.md サンプル（プロジェクトルートに配置）
----
-version: "1.0"
-name: "My App"
-colors:
-  Primary: "#1A73E8"
-components:
-  Button.primary:
-    background: "{colors.Primary}"
----
-```
-
-仕様: [google-labs-code/design.md](https://github.com/google-labs-code/design.md)
-
----
-
-## 🆕 v1.12.0 — Meta-Design Context Layer（project_lexicon）
-
-CoDD に **メタ設計コンテキスト層** が追加。プロジェクトの語彙・命名規約・設計原則を `project_lexicon.yaml` に一度宣言すれば、すべてのAIコマンド（require / plan / generate / implement）が自動でそれを使用する。
-
-- 📖 `ProjectLexicon` — ノード語彙、命名規約、設計原則、failure modes を宣言
-- 🌐 `KnowledgeFetcher` — Web Search 優先のナレッジ層、30日キャッシュ。CoDD コアにフレームワーク知識のハードコードゼロ
-- 🔍 `codd validate --lexicon` — lexicon 内の命名規約違反を検出
-- 🔌 Extractor registry — Python module path で extractor クラスを宣言。`FileSystemRouteExtractor` が初の登録例
-- 🧙 Lexicon wizard — `codd plan` が lexicon 不在時に draft `project_lexicon.yaml` を自動生成
-- 📋 `CoverageAuditor` — 要件ギャップ検出、AUTO_ACCEPT / ASK / AUTO_REJECT の3クラスルール
-- 🏷️ Provenance tracking — 各 lexicon エントリは `provenance` / `confidence` / `fetched_at` を保持
-
----
-
-## 🆕 v1.11.0 — Filesystem-Routing Aware Drift Detection
-
-CoDD が filesystem-routing フレームワーク（Next.js, SvelteKit, Nuxt, Astro, Remix）を理解し、設計書と実装間の URL drift を検出可能に。
-
-- 📐 `FileSystemRouteExtractor` — ディレクトリ構造から endpoint ノードを抽出
-- 🔗 `DocumentUrlLinker` — 設計書の URL を endpoint に自動リンク
-- 🔍 `codd drift` — 設計と実装の URL ギャップを検出
-- 🎨 `codd extract --layer routes` — screen-flow ダイアグラムを逆生成
-
-詳細は英語版README の [Filesystem Routing Adapter Recipes](README.md#filesystem-routing-adapter-recipes) を参照。
-
----
-
-**v1.9.0** — `codd implement` が**マルチAIエンジン**（Claude stdout + Codex file-writing）と**フェーズ内自動並列実行**（git worktree分離）に対応。フェーズマイルストーン形式（`#### M1.1`）をサポート。重い推論モデル向けにタイムアウトを1時間に拡大。SWE-bench Verified: **73/73 = 100%** 解決。
-
----
-
-## なぜCoDD？
-
-AIは仕様を書ける。でも**上流が変わったら？**
-
-あらゆるSpec-firstツールは「作る」ところで止まる。CoDDはそこから始まる。要件が変わったとき、コードが更新されたとき、設計の前提が崩れたとき、CoDDが**変更を下流に自動伝搬**する — 影響を受ける設計書を更新し、古くなった成果物をフラグし、エビデンスの証跡を残す。
-
-```
-要件が変わった → codd impact が影響設計書6本を特定
-コードが変わった → codd propagate が下流設計書を更新
-設計が変わった → CEGグラフが全依存先を追跡
-```
-
-他のツールにはこれができない。spec-kit、Kiro、cc-sddは文書を作る。**CoDDは文書の一貫性を維持する。**
-
-## 動作の仕組み
-
-```
-要件定義 (人間)  →  設計書生成 (AI)  →  コード & テスト (AI)
-       ↕                   ↕                    ↕
-   codd impact       codd propagate        codd extract
-  (何が変わった？)    (下流を更新)         (逆生成)
-```
-
-### 3つのレイヤー
-
-```
-ハーネス (CLAUDE.md, Hooks, Skills)   ← ルール、ガードレール、フロー
-  └─ CoDD (方法論)                     ← 変更時の一貫性維持
-       └─ 設計書 (docs/*.md)           ← CoDDが管理する成果物
-```
-
-CoDDは**ハーネス非依存** — Claude Code、Copilot、Cursor、どのエージェントフレームワークでも動きます。
-
-## 基本原則：設定するな、導出せよ
-
-| アーキテクチャ | 導出されるテスト戦略 | 設定は？ |
-|---|---|---|
-| Next.js + Supabase | vitest + Playwright | 不要 |
-| FastAPI + Python | pytest + httpx | 不要 |
-| CLI tool in Go | go test | 不要 |
-
-**上流が下流を決定する。** 要件と制約を定義するだけ。AIがそれ以外を全て導出します。
-
-## クイックスタート
-
-### グリーンフィールド（新規プロジェクト）
+人間が書くのは **「何を」と「どこまで」** だけ。「どう書くか」は CoDD と LLM が引き受ける。
 
 ```bash
 pip install codd-dev
-mkdir my-project && cd my-project && git init
-
-# 初期化 — 要件定義ファイルを渡すだけ（形式自由: txt, md, doc）
-codd init --project-name "my-project" --language "typescript" \
-  --requirements spec.txt
-
-# AIが設計書の依存グラフを設計
-codd plan --init
-
-# 設計書をwave順に生成
-waves=$(codd plan --waves)
-for wave in $(seq 1 $waves); do
-  codd generate --wave $wave
-done
-
-# 品質ゲート — AIの手抜きを検出（TODO、プレースホルダー）
-codd validate
-
-# 設計書からコード生成
-codd implement
-
-# コード断片をビルド可能なプロジェクトに統合
-codd assemble
 ```
 
-### ブラウンフィールド（既存プロジェクト）
-
-```bash
-codd extract              # 既存コードから設計書を逆生成
-codd require              # コードから要件を推論（何が作られ、なぜか）
-codd plan --init          # 抽出結果からwave_config生成
-codd scan                 # 依存グラフ構築
-codd impact               # 変更影響分析
-codd audit --skip-review  # 変更レビュー一括実行: validate + impact + policy
-codd measure              # プロジェクト健全性スコア（0-100）
-```
-
-## デモ
-
-### 再現可能なE2Eデモ — 3つの伝搬パターン
-
-以下のデモはコミット [`d7d9f45`](https://github.com/yohey-w/codd-dev/commit/d7d9f45) に固定されている。ローカルで完全再現可能。
-
-**セットアップ:**
-```bash
-pip install codd-dev>=1.6.0
-mkdir demo && cd demo && git init
-cat > spec.txt << 'EOF'
-TaskFlow — Requirements
-- User authentication (email + Google OAuth)
-- Workspace management (teams, roles, invites)
-- Task CRUD with assignees, labels, due dates
-- Real-time updates (WebSocket)
-- File attachments (S3)
-- Notification system (in-app + email)
-EOF
-codd init --project-name "taskflow" --language "typescript" --requirements spec.txt
-```
-
-**パターン1 — Source → Doc**（仕様 → 設計書）:
-```bash
-codd plan --init
-for wave in $(seq 1 $(codd plan --waves)); do codd generate --wave $wave; done
-codd validate        # 期待値: PASS, エラー0件
-codd scan            # 期待値: 17ノード, 30+エッジ
-```
-
-**パターン2 — Doc → Doc**（要件変更 → 下流更新）:
-```bash
-# 要件を編集: 認証に「SSO (SAML 2.0)」を追加
-codd impact          # 期待値: 7本中6本がGreen/Amberバンド
-
-# 影響を受けたWaveを再生成（propagateはコード→設計書方向のみ）
-codd generate --wave 1 --force   # 更新された要件から受入基準を再導出
-codd generate --wave 2 --force   # 更新されたWave 1からシステム設計を再導出
-# 影響のある各Waveを依存順に繰り返す
-```
-
-**パターン3 — Doc → Doc via CEG**（コード変更 → 設計書更新）:
-```bash
-# authモジュールのソースコードを変更
-codd propagate       # 期待値: auth-design, system-designが影響あり
-codd propagate --update  # コードdiffからAIが影響設計書を更新
-```
-
-**期待出力**: 20行のspec → 17設計成果物（5,100行超） → 変更後もpropagateで全文書の一貫性を維持。パターン3（CEGベースの伝搬）は新規性が高い — コード変更を依存グラフ経由で設計書まで遡って更新するツールは他にない。
-
-### グリーンフィールド — specから動くアプリまで
-
-37行のspec → 設計書6本（1,353行） → コード102ファイル（6,445行） → TypeScript strictビルド成功。AIチャットなし — ワークフロー全体がシェルスクリプト。
-
-詳細: [Harness as Code — CoDD活用ガイド #1](https://zenn.dev/shio_shoppaize/articles/codd-greenfield-guide)
-
-### ブラウンフィールド — 変更影響分析
-
-要件を2行変えただけで、`codd impact` が7本中6本の設計書に影響ありと判定。Green帯域はAIが自動更新。Amber帯域は人間に提示。変更が怖くなくなる。
-
-詳細: [CoDD 詳細解説](https://zenn.dev/shio_shoppaize/articles/shogun-codd-coherence)
-
-## Wave順生成
-
-設計書は依存関係の順序で生成されます — 各Waveは前のWaveに依存：
-
-```
-Wave 1  受入基準 + ADR                ← 要件のみ
-Wave 2  システム設計                   ← 要件 + Wave 1
-Wave 3  DB設計 + API設計             ← 要件 + Wave 1-2
-Wave 4  UI/UX設計                    ← 要件 + Wave 1-3
-Wave 5  実装計画                      ← 上記すべて
-```
-
-検証はボトムアップ（V-Model）：
-
-```
-ユニットテスト    ← 詳細設計を検証
-結合テスト       ← システム設計を検証
-E2E/システムテスト ← 要件 + 受入基準を検証
-```
-
-## フロントマター = 唯一の信頼できるソース
-
-依存関係はMarkdownのフロントマターで宣言。別途設定ファイルは不要。
-
-```yaml
 ---
-codd:
-  node_id: "design:api-design"
-  modules: ["api", "auth"]        # ← ソースコードモジュールとの紐付け
-  depends_on:
-    - id: "design:system-design"
-      relation: derives_from
-    - id: "req:my-project-requirements"
-      relation: implements
----
+
+## Quick Start (5 分)
+
+### 1. インストール
+
+```bash
+pip install codd-dev
+codd --version  # 1.34.0 以上
 ```
 
-`modules` フィールドが逆方向トレーサビリティを実現する：ソースコードが変更されたとき、`codd extract` が影響モジュールを特定し、`modules` フィールドでそのモジュールに紐づく設計書を逆引きできる。
-
-`codd/scan/` はキャッシュ — `codd scan` のたびに再生成されます。
-
-## カスタムノードプレフィックス
-
-デフォルトでは `node_id` に使えるプレフィックスは組み込みのもの（`design:`, `req:`, `doc:`, `module:` 等）に限定されています。ソフトウェア設計以外の用途（ナレッジベース、レビュー文書、プロンプト管理など）に使う場合、`codd.yaml` でカスタムプレフィックスを追加できます：
+### 2. プロジェクトに codd.yaml を置く
 
 ```yaml
 # codd.yaml
-prefixes:
-  - knowledge
-  - schema
-  - review
-  - prompt
+codd_required_version: ">=1.34.0"
+
+dag:
+  design_docs:
+    - "docs/design/**/*.md"
+  implementations:
+    - "src/**/*.{ts,tsx,py}"
+  tests:
+    - "tests/**/*.{spec,test}.{ts,tsx,py}"
+
+repair:
+  approval_mode: required   # 自動修復には人の承認を要する
+  max_attempts: 10
+
+llm:
+  ai_command: "claude"      # 任意の LLM CLI を呼び出せる (claude / codex / gemini 等)
 ```
 
-カスタムプレフィックスは組み込みデフォルトに**マージ**されます。`design` や `req` を再指定する必要はありません。プレフィックス名は小文字英字とアンダースコアのみ（`[a-z_]+`）です。
-
-```yaml
-# フロントマターで使用可能に:
-codd:
-  node_id: "knowledge:domain-model"
-```
-
-## AIモデル設定
-
-CoDDは設計書生成に外部AI CLIを呼び出す。デフォルトはClaude Opus：
-
-```yaml
-# codd.yaml
-ai_command: "claude --print --model claude-opus-4-6"
-```
-
-### コマンド別オーバーライド
-
-コマンドごとに異なるモデルを使い分けられる。例えば、設計書生成はOpus、コード実装はCodex：
-
-```yaml
-ai_command: "claude --print --model claude-opus-4-6"   # グローバルデフォルト
-ai_commands:
-  generate: "claude --print --model claude-opus-4-6"    # 設計書生成
-  restore: "claude --print --model claude-opus-4-6"     # ブラウンフィールド復元
-  review: "claude --print --model claude-opus-4-6"      # 品質評価
-  plan_init: "claude --print --model claude-sonnet-4-6" # wave_config計画
-  implement: "codex --print"                             # コード生成
-```
-
-**優先順位**: CLI `--ai-cmd` フラグ > `ai_commands.{コマンド}` > `ai_command` > ビルトインデフォルト（Opus）。
-
-### Claude Codeのコンテキスト干渉
-
-`claude --print` をプロジェクトディレクトリ内で実行すると、`CLAUDE.md` を自動検出してプロジェクトレベルのシステムプロンプトを読み込む。これらの指示がCoDDの生成プロンプトと競合し、フォーマットバリデーション失敗を起こすことがある：
-
-```
-Error: AI command returned unstructured summary for 'ADR: ...'; missing section headings
-```
-
-**対策**: `--system-prompt` でプロジェクトコンテキストを上書きし、文書生成に集中させる：
-
-```yaml
-ai_command: "claude --print --model claude-opus-4-6 --system-prompt 'You are a technical document generator. Output only the requested Markdown document. Follow section heading instructions exactly.'"
-```
-
-> **注意**: `--bare` は全コンテキストを排除するが、OAuth認証まで無効化してしまう。`--system-prompt` を使えば `CLAUDE.md` を上書きしつつ認証は維持できる。
-
-## 設定ディレクトリの自動検出
-
-デフォルトでは `codd init` は `codd/` ディレクトリを作成する。プロジェクトに既に `codd/` が存在する場合（例：ソースコードのパッケージ名）、`--config-dir` で別名を指定できる：
+### 3. 典型コマンド
 
 ```bash
-codd init --config-dir .codd --project-name "my-project" --language "python"
+# 整合性検証 (要件・設計・実装・テストの一貫性チェック)
+codd dag verify
+
+# 自動修復付き検証 (違反を見つけたら LLM が patch を生成・適用)
+codd dag verify --auto-repair --max-attempts 10
+
+# User Journey の実機 PASS 確認 (CDP 経由でブラウザ操作)
+codd dag run-journey login_to_dashboard --axis viewport=smartphone_se
+
+# 設計書から実装手順を導出 (実装段階の入力)
+codd implement run --task M1.2 --enable-typecheck-loop
 ```
 
-`scan`、`impact`、`generate` 等の全コマンドは、`codd/` → `.codd/` の順で設定ディレクトリを自動検出する。追加フラグは不要。
+### 4. 出力の見方
 
-## ブラウンフィールド？ ここから
+`codd dag verify` は 9 種の coherence check を走らせる:
 
-既存コードベースがある場合、CoDDはコード抽出から設計書復元までの完全なブラウンフィールドワークフローを提供する。
-
-ウォークスルー: [Harness as Code — CoDD実践ガイド #2 ブラウンフィールド編](https://zenn.dev/shio_shoppaize/articles/shogun-codd-brownfield)
-
-### AI抽出（--ai）
-
-> **プリセットについて**: `codd extract --ai` には**baseline**プリセット（公開用）が同梱されている。公開ベンチマーク（F1 0.953+）の数値は、チューニング済みプリセットと内部評価セットで測定した結果であり、公開版baselineとは異なる。baselineは同じワークフローと出力形式を使えるが、結果はコードベースやプロンプトにより変動する。`--prompt-file` で独自のプロンプトを渡すことも可能。
-
-```bash
-codd extract --ai                        # 組み込みbaselineプリセットを使用
-codd extract --ai --prompt-file my.md    # カスタムプロンプトを使用
-```
-
-### Step 1: コードから構造を抽出
-
-`codd extract` がソースコードから設計書を逆生成する。AI不要——純粋な静的解析。
-
-```bash
-cd existing-project
-codd extract
-```
-
-```
-Extracted: 13 modules from 45 files (12,340 lines)
-Output: codd/extracted/
-  system-context.md     # モジュールマップ + 依存グラフ
-  modules/auth.md       # モジュール別設計書
-  modules/api.md
-  modules/db.md
-  ...
-```
-
-### Step 2: 抽出結果からwave_configを生成
-
-`codd plan --init` は抽出済み設計書を自動検出し、要件定義なしでwave_configを生成する。
-
-```bash
-codd plan --init    # codd/extracted/ を検出し、ブラウンフィールド用wave_configを生成
-```
-
-生成されたwave_configの各成果物には `modules` フィールドが含まれ、ソースコードモジュールとの逆方向トレーサビリティを実現する。
-
-### Step 3: 設計書を復元
-
-`codd restore` は抽出された事実から設計書を復元する。`codd generate`（要件から設計書を生成）とは根本的に異なり、「現在の設計は何か？」をコード構造から再構築する。
-
-```bash
-codd restore --wave 2   # 抽出事実からシステム設計を復元
-codd restore --wave 3   # DB設計・API設計を復元
-```
-
-### Step 4: 依存グラフを構築
-
-```bash
-codd scan
-codd impact
-```
-
-**設計思想**: V-Modelにおいて、意図は要件定義にのみ存在する。アーキテクチャ・詳細設計・テストは構造事実——コードから抽出可能。`codd extract` は構造を取り、`codd restore` は設計を復元し、「なぜ」は後から人が加える。
-
-### グリーンフィールド vs ブラウンフィールド
-
-| | グリーンフィールド | ブラウンフィールド |
-|--|-----------|-----------|
-| 起点 | 要件定義（人間が記述） | 既存コードベース |
-| 計画 | `codd plan --init`（要件から） | `codd plan --init`（抽出結果から） |
-| 設計書生成 | `codd generate`（順方向: 要件→設計） | `codd restore`（逆方向: コード事実→設計） |
-| トレーサビリティ | `modules` フィールドが設計書→コードを接続 | 同じ |
-| 変更時 | `codd propagate`（コード→影響設計書→AI更新） | 同じ |
-
-## コマンド
-
-| コマンド | ステータス | 説明 |
-|---------|--------|-------------|
-| `codd init` | **安定版** | プロジェクト初期化（`--config-dir .codd` で設定ディレクトリ名を変更可） |
-| `codd scan` | **安定版** | フロントマターから依存グラフ構築 |
-| `codd impact` | **安定版** | 変更影響分析（Green / Amber / Gray バンド） |
-| `codd validate` | **アルファ** | フロントマター整合性 & グラフ一貫性チェック |
-| `codd generate` | 実験的 | Wave順で設計書生成（グリーンフィールド） |
-| `codd restore` | 実験的 | 抽出事実から設計書を復元（ブラウンフィールド） |
-| `codd plan` | 実験的 | Wave実行状況（`--init` はブラウンフィールドにも対応） |
-| `codd verify` | 実験的 (Pro) | V-Model検証 |
-| `codd implement` | 実験的 | 設計書→コード生成 |
-| `codd propagate` | **アルファ** | コード/設計変更を下流の影響設計書に伝搬 |
-| `codd review` | 実験的 (Pro) | AI品質評価（LLM-as-Judge） |
-| `codd extract` | **アルファ** | 既存コードから設計書を逆生成 |
-| `codd require` | **アルファ** | 既存コードベースから要件を推論（ブラウンフィールド） |
-| `codd audit` | **アルファ** (Pro) | 変更レビュー一括パック（validate + impact + policy + review） |
-| `codd policy` | **アルファ** | エンタープライズポリシーチェッカー（ソースコードの禁止/必須パターン） |
-| `codd measure` | **アルファ** | プロジェクト健全性メトリクス（グラフ、カバレッジ、品質、スコア 0-100） |
-| `codd mcp-server` | **アルファ** | AIツール連携用MCPサーバー（stdio、依存ゼロ） |
-| `codd fix` | **アルファ** | テスト/ビルド失敗の自動修正（診断推論 + セッション状態永続化） |
-
-## SWE-bench Verified
-
-CoDDの `fix` コマンドは、診断推論ステップにより [SWE-bench Verified](https://www.swebench.com/verified.html) のキュレーション済みサブセットで **73/73 = 100%** を達成。診断ステップがパッチ前の根本原因分析を強制し、セッション状態が失敗アプローチの繰り返しを防止する。
-
-| 指標 | 結果 |
-|--------|--------|
-| インスタンス数 | 73（SWE-bench Verifiedからキュレーション） |
-| 解決数 | **73（100%）** |
-| 主要機能 | 診断推論 + セッション状態永続化 |
-
-詳細: [Zenn: CoDD SWE-bench Guide](https://zenn.dev/shio_shoppaize/articles/codd-swebench-pilot?locale=en)
-
-## OSS / Pro 分離
-
-CoDD v1.6.0でOSS/Proの境界をブリッジパターンで明確化。
-
-**OSS（MIT、無料）** — 文書の一貫性維持に必要な全機能:
-
-`init` · `scan` · `impact` · `generate` · `restore` · `propagate` · `extract` · `require` · `plan` · `validate` · `measure` · `policy` · `fix` · `mcp-server`
-
-**Pro（プライベート、有料）** — エンタープライズ向けレビュー・検証:
-
-`review` · `verify` · `audit` · `risk`
-
-```bash
-# OSSのみ
-pip install codd-dev
-
-# Pro拡張を追加
-pip install "codd-pro @ git+ssh://git@github.com/yohey-w/codd-pro.git"
-```
-
-`codd-pro` がインストールされていれば、entry-pointsプラグイン探索でPro実装がOSSフォールバックを自動的にオーバーライドする。未インストール時はマイグレーションメッセージを表示して正常終了。設定変更は不要。
-
-## CI連携（GitHub Action）
-
-プルリクエストごとにCoDD監査を実行。判定結果（APPROVE / CONDITIONAL / REJECT）、バリデーション結果、ポリシー違反、影響分析をコメントとして投稿する。
-
-### クイックセットアップ
-
-プロジェクトに `.github/workflows/codd.yml` を追加:
-
-```yaml
-name: CoDD Audit
-on:
-  pull_request:
-    branches: [main]
-
-permissions:
-  contents: read
-  pull-requests: write
-
-jobs:
-  audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: yohey-w/codd-dev@main
-        with:
-          diff-target: origin/${{ github.base_ref }}
-          skip-review: "true"  # AIレビューを有効にするには "false" に設定
-```
-
-### Action入力
-
-| 入力 | デフォルト | 説明 |
-|------|-----------|------|
-| `diff-target` | `origin/main` | 差分比較対象のGit ref |
-| `skip-review` | `true` | AIレビューフェーズをスキップ（高速、AIコスト不要） |
-| `python-version` | `3.12` | Pythonバージョン |
-| `codd-version` | 最新版 | 特定バージョン（例: `>=1.3.0`） |
-| `post-comment` | `true` | 結果をPRコメントとして投稿 |
-
-### Action出力
-
-| 出力 | 説明 |
-|------|------|
-| `verdict` | `APPROVE`、`CONDITIONAL`、または `REJECT` |
-| `risk-level` | `LOW`、`MEDIUM`、または `HIGH` |
-| `report-json` | JSON監査レポートへのパス |
-
-### エンタープライズポリシー
-
-`codd.yaml` でソースコードポリシーを定義:
-
-```yaml
-policies:
-  - id: SEC-001
-    description: "ハードコードされたパスワードの禁止"
-    severity: CRITICAL
-    kind: forbidden
-    pattern: 'password\s*=\s*[''"]'
-    glob: "*.py"
-
-  - id: LOG-001
-    description: "全モジュールにloggingのimportが必要"
-    severity: WARNING
-    kind: required
-    pattern: "import logging"
-    glob: "*.py"
-```
-
-ポリシーチェッカーは `codd audit` の一部として実行され、`codd policy` で単独実行も可能。CRITICAL違反はREJECT、WARNINGはCONDITIONALを返す。
-
-## MCPサーバー
-
-CoDDは [Model Context Protocol](https://modelcontextprotocol.io/) 経由でツールを公開し、AIツールとの直接連携を実現する。外部依存ゼロ — MCP対応クライアントならどれでも動作。
-
-```bash
-codd mcp-server --project /path/to/your/project
-```
-
-### Claude Code設定
-
-`~/.claude/claude_code_config.json` に追加:
-
-```json
-{
-  "mcpServers": {
-    "codd": {
-      "command": "codd",
-      "args": ["mcp-server", "--project", "/path/to/your/project"]
-    }
-  }
-}
-```
-
-### 利用可能なMCPツール
-
-| ツール | 説明 |
-|--------|------|
-| `codd_validate` | フロントマター整合性とグラフ一貫性チェック |
-| `codd_impact` | 指定ノードまたはファイルの変更影響分析 |
-| `codd_policy` | エンタープライズポリシールールに対するソースコードチェック |
-| `codd_audit` | 変更レビュー一括実行（validate + impact + policy） |
-| `codd_scan` | 設計書から依存グラフ構築 |
-| `codd_measure` | プロジェクト健全性メトリクス（グラフ、カバレッジ、品質、スコア） |
-
-## Claude Code 連携
-
-CoDDはClaude Code用のスラッシュコマンドSkillを同梱。CLIを直接叩く代わりに、Skillを使えばClaudeがプロジェクトの状態を読み取って適切なコマンドを実行する。
-
-### Skills デモ — 同じTaskFlowアプリ、CLIコマンド不要
-
-```
-殿:  /codd-init
-     → Claude: codd init --project-name "taskflow" --language "typescript" \
-                 --requirements spec.txt
-
-殿:  /codd-generate
-     → Claude: codd generate --wave 2 --path .
-     → Claude が生成された設計書を読み、スコープ確認、フロントマター検証
-     → 「Wave 2の設計書を確認しました。Wave 3に進みますか？」
-
-殿:  はい
-
-殿:  /codd-generate
-     → Claude: codd generate --wave 3 --path .
-
-殿:  /codd-scan
-     → Claude: codd scan --path .
-     → 報告: 「7ドキュメント、15エッジ。警告なし。」
-
-殿:  （要件を編集 — SSO対応と監査ログを追加）
-
-殿:  /codd-impact
-     → Claude: codd impact --path .
-     → Green帯域: system-design、api-design、db-design、auth-designを自動更新
-     → Amber帯域: 「test-strategyが影響を受けています。更新しますか？」
-
-殿:  （ソースコードを変更 — SSO機能を実装）
-
-殿:  /codd-propagate
-     → Claude: codd propagate --path .
-     → 「authモジュールで3ファイル変更。影響を受ける設計書2件:
-        design:system-design, design:auth-detail」
-     → 「--updateで設計書を更新しますか？」
-
-殿:  はい
-     → Claude: codd propagate --path . --update
-     → 更新された設計書をレビューし、変更内容が正確か確認
-```
-
-**CLIとの違い**: Skillはhuman-in-the-loopゲートを追加する。`/codd-generate` はWave間で承認を求めて停止。`/codd-impact` はGreen/Amber/Grayプロトコルに従い、安全な変更は自動更新、リスクのある変更は確認してから実行。
-
-### フック連携 — 一度設定したら、もう意識しなくていい
-
-このフックを入れれば、**`codd scan` を手動で叩く必要は二度とない。** ファイル編集のたびに自動実行 — 依存グラフは常に最新、常に正確、意識ゼロ：
-
-```json
-{
-  "hooks": {
-    "PostToolUse": [{
-      "matcher": "Edit|Write",
-      "hooks": [{
-        "type": "command",
-        "command": "codd scan --path ."
-      }]
-    }]
-  }
-}
-```
-
-フックが有効なら、やることは**普通にファイルを編集して、影響を知りたくなったら `/codd-impact` を叩く。それだけ。** グラフのメンテナンスは完全に透明。
-
-### 利用可能なSkill
-
-| Skill | 機能 |
+| Check | 役割 |
 |-------|------|
-| `/codd-init` | 初期化 + 要件インポート |
-| `/codd-generate` | HITLゲート付きWave順設計書生成（グリーンフィールド） |
-| `/codd-restore` | 抽出事実から設計書復元（ブラウンフィールド） |
-| `/codd-scan` | 依存グラフ再構築 |
-| `/codd-impact` | Green/Amber/Grayプロトコルで変更影響分析 |
-| `/codd-validate` | フロントマター & 依存関係の整合性チェック |
-| `/codd-propagate` | ソースコード変更を設計書に逆伝搬 |
-| `/codd-review` | AI品質レビュー（PASS/FAIL判定 + フィードバック） |
+| `node_completeness` | 設計書記載のノード (実装/テスト) が物理ファイルとして存在するか |
+| `transitive_closure` | 要件 → 設計 → 実装 → テストの依存連鎖が閉じているか |
+| `verification_test_runtime` | 実装に対するテストが実行可能で PASS するか |
+| `deployment_completeness` | デプロイチェーン (Dockerfile/compose/k8s) が完備か |
+| `proof_break_authority` | 重要 journey が壊れていないか |
+| `screen_flow_edges` | 画面遷移グラフに孤立ノードがないか |
+| `screen_flow_completeness` | 全画面が要件にマップされているか |
+| `c8` | uncommitted patch / dirty file の検知 |
+| `c9` (`environment_coverage`) | viewport / RBAC role / locale 等の **対象環境網羅性** |
 
-詳細は [docs/claude-code-setup_ja.md](docs/claude-code-setup_ja.md) を参照。
+violation が見つかれば deploy gate を block、`--auto-repair` で LLM patch 生成 → 適用 → 再検証のループに入る。
 
-## 自律品質ループ
+---
 
-`codd review` はAI（LLM-as-Judge）で成果物を評価し、`--feedback` はその結果を再生成に食わせる。組み合わせることで完全自律の品質ループが回る：
+## 典型ユースケース
 
-```bash
-# 生成 → レビュー → フィードバック付き再生成 → PASSするまで繰り返し
-codd generate --wave 2 --force
-feedback=$(codd review --path . --json | jq -r '.results[0].feedback')
-verdict=$(codd review --path . --json | jq -r '.results[0].verdict')
+### ユースケース 1: 要件 → 設計 → 実装の自動化
 
-while [ "$verdict" = "FAIL" ]; do
-  codd generate --wave 2 --force --feedback "$feedback"
-  result=$(codd review --path . --json)
-  verdict=$(echo "$result" | jq -r '.results[0].verdict')
-  feedback=$(echo "$result" | jq -r '.results[0].feedback')
-done
+`docs/requirements/*.md` に「機能要件 + 制約」を書き、`codd implement run` を呼ぶと:
+
+1. 要件から ImplStep 列を LLM が動的導出 (Layer 1)
+2. ベストプラクティス補完 (Layer 2、ログイン → ログアウト/Remember Me/セッションタイムアウト 等)
+3. ユーザー承認 (HITL gate) を経て `src/**` に実装が生成される
+4. 生成中に `tsc` などの type check が落ちれば自動修復ループに入る
+
+人間は「機能要件 + 制約だけ書けば全自動」を体験できる。
+
+### ユースケース 2: Auto-Repair (codd verify --auto-repair)
+
+CI で `codd dag verify --auto-repair --max-attempts 10` を回すと:
+
+1. 9 種の coherence check が実行される
+2. 違反を **修復可能 (in-task) / pre-existing (baseline) / unrepairable** に Hybrid Classifier (git diff + LLM) で分類
+3. 修復可能違反のうち DAG 上最も上流のものを選んで LLM が patch 生成
+4. dry-run validation を経て apply、再検証
+5. max_attempts 内で全解消 → `SUCCESS`、一部修復 → `PARTIAL_SUCCESS`、修復不能ばかり → `REPAIR_FAILED`
+
+`PARTIAL_SUCCESS` でも修復済 patch は反映され、残違反は report に列挙される (透明性)。
+
+### ユースケース 3: User Journey Coherence (codd dag run-journey)
+
+`docs/design/auth_design.md` の frontmatter にユーザージャーニーを書く:
+
+```yaml
+user_journeys:
+  - name: login_to_dashboard
+    criticality: critical
+    steps:
+      - { action: navigate, target: "/login" }
+      - { action: fill, selector: "input[type=email]", value: "user@example.com" }
+      - { action: click, selector: "button[type=submit]" }
+      - { action: expect_url, value: "/dashboard" }
 ```
 
-レビュー基準はドキュメントタイプ別：
+`codd dag run-journey login_to_dashboard --axis viewport=smartphone_se` で:
 
-| タイプ | 評価基準 |
-|--------|----------|
-| 要件定義 | 網羅性、一貫性、テスト可能性、曖昧さ |
-| 設計 | アーキテクチャ妥当性、API品質、セキュリティ、上流整合性 |
-| 詳細設計 | 実装明確性、データモデル、エラー処理、インターフェース契約 |
-| テスト | カバレッジ、エッジケース、独立性、トレーサビリティ |
+- `project_lexicon.yaml` 宣言の `viewport=smartphone_se` (375x667) を CDP に runtime 注入
+- 実機ブラウザ (Edge / Chrome) で journey を実行
+- 失敗時は `codd dag verify` の C9 environment_coverage が deploy gate を block
 
-**スコアリング**: 80点以上 = PASS。CRITICALイシューは自動で59点に上限。FAIL時はexit code 1 — ループ親和。
+スマホ専用 nav が消えてた等の事故を構造的に防ぐ。
 
-**モデル配置**: レビューはOpus（`ai_commands.review`）、実装はCodex（`ai_commands.implement`）。`ai_commands` 設定で1行で切り替え。
+---
 
-## 他のSpec駆動ツールとの違い
+## v1.34.0 主要機能
 
-主要なSpec駆動ツールはすべて設計書の**作成**に焦点を当てている。設計書が**変更された後**に何が起きるかに対処するツールはない。CoDDは依存グラフ、影響分析、バンドベースの更新プロトコルでそのギャップを埋める。
+| 機能 | 役割 |
+|------|------|
+| **DAG 完全性** (C1〜C8) | 要件・設計・実装・テスト・デプロイの 9 種コヒーレンスチェック |
+| **Coverage Axis Layer** (C9) | viewport / RBAC role / locale 等の **対象環境網羅性** を統一抽象 (16+ 軸対応) で検証 |
+| **LLM Auto-Repair (RepairLoop)** | 違反検知 → LLM patch 生成 → apply → 再検証のループ、`max_attempts` 内で全解消を試行 |
+| **Hybrid Classifier** | git diff (Stage 1) + LLM 判断 (Stage 2) で violation を repairable / pre_existing / unrepairable に分類 |
+| **Primary Picker** | 複数違反のうち DAG 上最も上流のもの (root cause 候補) を優先修復 |
+| **PARTIAL_SUCCESS policy** | applied_patches OR pre_existing OR unrepairable があれば PARTIAL_SUCCESS、CI を release blocker から外せる |
+| **BestPracticeAugmenter** | 設計書に明記されないベストプラクティス (パスワードリセット等) を LLM が動的補完 |
+| **ImplStepDeriver (2-layer)** | 設計書 → ImplStep 列の動的展開、Layer 2 で `required_axes` 推論 |
+| **Typecheck Repair Loop** | 実装段階で `tsc --noEmit` などの type check が落ちたら自動修復ループ |
+| **`codd version --check --strict`** | プロジェクト要求 vs インストール済 codd の差分検出 |
 
-| | **spec-kit** (GitHub) | **Kiro** (AWS) | **cc-sdd** (gotalab) | **CoDD** |
-|--|---|---|---|---|
-| 焦点 | Spec作成（要件→設計→タスク→コード） | Agentic IDE + SDD | Kiro式SDDのClaude Code版 | **作成後の一貫性維持** |
-| Stars | 83.7k | N/A（プロプラIDE） | 3k | -- |
-| 変更伝播 | No | No | No | **`codd impact` + 依存グラフ** |
-| 影響分析 | No | No | No | **Green / Amber / Gray バンド** |
-| 仕様記法 | Markdown + 40拡張 | EARS記法 | 品質ゲート + git worktree | フロントマター `depends_on` |
-| ハーネスロックイン | GitHub Copilot | Kiro IDE | Claude Code | **任意のエージェント / IDE** |
+詳細は [CHANGELOG.md](CHANGELOG.md) 参照。
 
-要約: spec-kit、Kiro、cc-sddは「仕様をどう作るか」に答える。CoDDは「上流が変わったとき、下流を自動で更新する」に答える。
+---
 
-## 比較
+## 実証ケーススタディ — osato-lms (LMS Web App)
 
-|  | Spec Kit | OpenSpec | **CoDD** |
-|--|----------|---------|----------|
-| 仕様を先に書く | Yes | Yes | Yes |
-| **変更伝播** | No | No | **依存グラフ + 影響分析** |
-| **テスト戦略の自動導出** | No | No | **アーキテクチャから自動** |
-| **V-Model検証** | No | No | **Unit → Integration → E2E** |
-| **影響分析** | No | No | **`codd impact`** |
-| ハーネス非依存 | Copilot寄り | マルチエージェント | **どのハーネスでも** |
-
-## 実プロジェクト実績
-
-本番Webアプリで実証済み — 18の設計書が依存グラフで接続。設計書・コード・テストの全てをAIがCoDDに従って生成。プロジェクト途中で要件が変更された際、`codd impact` が影響を受ける成果物を特定し、AIが自動で修正。
+社内 LMS プロジェクト osato-lms (Next.js + Prisma + PostgreSQL) で `codd verify --auto-repair --max-attempts 10` を実行した結果:
 
 ```
-docs/
-├── requirements/       # 何を作るか（人間の入力）
-├── design/             # システム設計、API、DB、UI（6ファイル）
-├── detailed_design/    # モジュールレベルの仕様（4ファイル）
-├── governance/         # ADR（3ファイル）
-├── plan/               # 実装計画
-├── test/               # 受入基準、テスト戦略
-├── operations/         # 運用手順書
-└── infra/              # インフラ設計
+status:                PARTIAL_SUCCESS
+attempts:              4
+applied_patches:       4
+pre_existing_violations:  1
+unrepairable_violations:  2
+remaining_violations:     3 (skip + report 済み)
+smoke proof:           6 checks PASS
+CoDD core 改修:        0 行
 ```
 
-### CoDD自身の開発もCoDDで管理
+修復された file:
+- `tests/e2e/environment-coverage.spec.ts`
+- `tests/e2e/login.spec.ts`
 
-CoDDは自分自身をdogfoodingしている。`.codd/`ディレクトリにCoDD自身の設定があり、`codd extract`で自分のソースコードから設計書を逆生成する。V-Modelライフサイクル全体が自分自身に対して動く：
+スキップされた違反 (CoDD 責任外として report に明示):
+- pre_existing: deployment_completeness chain
+- unrepairable: Dockerfile dry-run patch validation
+- unrepairable: Vitest matcher runtime issue
 
-```bash
-codd init --config-dir .codd --project-name "codd-dev" --language "python"
-codd extract          # 15モジュール → 依存フロントマター付き設計書
-codd scan             # 49ノード、83エッジ
-codd verify           # mypy + pytest（434テスト通過）
-```
+C9 environment_coverage は viewport (smartphone_se / desktop_1920) と RBAC role (central_admin / tenant_admin / learner) の axis × variant 全網羅を検証、PASS 達成。
 
-自分自身を管理できないツールに、あなたのプロジェクトは任せられない。
+---
 
-## ロードマップ
+## アーキテクチャ — 4 release 進化
 
-- [ ] セマンティック依存関係タイプ (`requires`, `affects`, `verifies`, `implements`)
-- [x] `codd extract` — 既存コードベースから設計書を逆生成（ブラウンフィールド対応）
-- [x] `codd restore` — 抽出事実から設計書を復元（ブラウンフィールド設計書生成）
-- [x] `codd plan --init` ブラウンフィールド対応 — 抽出結果からwave_config生成
-- [x] `modules` フィールド — 設計書 ↔ ソースコードのトレーサビリティ
-- [x] コマンド別AIモデル設定（`ai_commands` in codd.yaml）
-- [x] `codd propagate` — ソースコード変更を設計書に逆伝搬
-- [x] `codd review` — AI品質評価 + レビュー駆動の再生成ループ
-- [x] `--feedback` フラグ — レビュー結果をgenerate/restore/propagateに食わせて再生成
-- [x] `codd verify` — 言語非依存の検証（Python: mypy + pytest、TypeScript: tsc + jest）
-- [x] `codd require` — 既存コードベースから要件を推論（確信度タグ付き）
-- [x] `codd audit` — 変更レビュー一括パック（validate + impact + policy + review）
-- [x] `codd policy` — エンタープライズポリシーチェッカー（禁止/必須パターン）
-- [x] `codd measure` — プロジェクト健全性メトリクス（グラフ、カバレッジ、品質、スコア 0-100）
-- [x] GitHub Action — PRの自動監査コメント付きCI連携
-- [x] MCPサーバー — AIツール連携用stdio JSON-RPCサーバー
-- [x] プラグインシステム — 拡張可能なrequireプロンプト（タグ、エビデンス形式、出力セクション）
-- [ ] マルチハーネス連携例（Claude Code, Copilot, Cursor）
-- [ ] VS Code拡張（影響分析の可視化）
+| Release | 到達点 |
+|---------|--------|
+| v1.31.0 | 内側 100% (内部整合性 coherence) — type check repair loop で「手動 type fix」を撲滅 |
+| v1.32.0 | 外側 100% (対象環境網羅性 Coverage Axis) — viewport/RBAC/locale 等を統一抽象で吸収 |
+| v1.33.0 | caveats 解消経路実証 — 実機 CDP run-journey + LLM auto-repair attempt PASS |
+| **v1.34.0** | **full pipeline 完全実証** — 実プロジェクトで auto-repair PARTIAL_SUCCESS 完走 |
 
-## 解説記事
+詳細は [CHANGELOG.md](CHANGELOG.md) で各 release を参照。
 
-- [Zenn: Harness as Code — CoDD活用ガイド #1 spec → 設計書 → コード](https://zenn.dev/shio_shoppaize/articles/codd-greenfield-guide)
-- [Zenn: Harness as Code — CoDD実践ガイド #2 ブラウンフィールド編](https://zenn.dev/shio_shoppaize/articles/shogun-codd-brownfield)
-- [Zenn: Harness as Code — CoDD活用ガイド #3 既存コードのバグ修正（SWE-bench実験）](https://zenn.dev/shio_shoppaize/articles/codd-swebench-pilot)
-- [Zenn: CoDD 詳細解説](https://zenn.dev/shio_shoppaize/articles/shogun-codd-coherence)
-- [dev.to: Harness as Code — Treating AI Workflows Like Infrastructure](https://dev.to/yohey-w/harness-as-code-treating-ai-workflows-like-infrastructure-27ni)
-- [dev.to: What Happens After "Spec First"](https://dev.to/yohey-w/codd-coherence-driven-development-what-happens-after-spec-first-514f)
+---
 
-## スポンサー
+## Generality Gate (汎用性絶対維持)
 
-<a href="https://github.com/sponsors/yohey-w">
-  <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?style=for-the-badge&logo=github-sponsors" alt="Sponsor">
-</a>
+CoDD core code には以下の hardcode を **禁止** している:
 
-スポンサーの支援がCoDD開発を継続可能にしています。[スポンサーTier](https://github.com/sponsors/yohey-w)を確認する。
+- 特定 stack 名 (Next.js / Django / Rails / FastAPI 等)
+- 特定 framework / library の literal
+- 特定 domain (Web / Mobile / Desktop / CLI / Backend / Embedded)
+- 特定 viewport 値 (375 / 1920 等) や device 名 (iPhone / Android 等)
+
+これらは全て **`project_lexicon.yaml` (プロジェクト固有)** に閉じる。CoDD は generic な violation object としてのみ処理する。
+
+LLM が「stack 固有の最適 patch」を提案する場合は、その判断は **LLM の知識** に委ね、CoDD core が決めない (= overfitting しない)。
+
+---
 
 ## ライセンス
 
-MIT
+MIT License — [LICENSE](LICENSE) 参照。
+
+## リンク
+
+- [CHANGELOG.md](CHANGELOG.md) — 全 release ノート
+- [GitHub Sponsors](https://github.com/sponsors/yohey-w) — 開発支援
+- [Issues](https://github.com/yohey-w/codd-dev/issues) — バグ報告 / 機能要望
+
+---
+
+> 「コードが変わったとき、CoDD は影響範囲を追跡し、違反を検出し、マージ判断のためのエビデンスを生成する。」

--- a/README_ja.md
+++ b/README_ja.md
@@ -163,9 +163,9 @@ user_journeys:
 
 ---
 
-## 実証ケーススタディ — osato-lms (LMS Web App)
+## 実証ケーススタディ — 実プロジェクト (LMS Web App)
 
-社内 LMS プロジェクト osato-lms (Next.js + Prisma + PostgreSQL) で `codd verify --auto-repair --max-attempts 10` を実行した結果:
+実プロジェクト (LMS アプリ、Next.js + Prisma + PostgreSQL) で `codd verify --auto-repair --max-attempts 10` を実行した結果:
 
 ```
 status:                PARTIAL_SUCCESS

--- a/README_zh.md
+++ b/README_zh.md
@@ -163,9 +163,9 @@ user_journeys:
 
 ---
 
-## 实证案例研究 — osato-lms (LMS Web App)
+## 实证案例研究 — 真实 LMS 项目
 
-在内部 LMS 项目 osato-lms (Next.js + Prisma + PostgreSQL) 上执行 `codd verify --auto-repair --max-attempts 10`，结果如下：
+在实际 LMS 项目 (Next.js + Prisma + PostgreSQL) 上执行 `codd verify --auto-repair --max-attempts 10`，结果如下：
 
 ```
 status:                PARTIAL_SUCCESS

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,6 +1,5 @@
 <p align="center">
-  <strong>CoDD — 一致性驱动开发（Coherence-Driven Development）</strong><br>
-  <em>AI 辅助开发中变更管理的证据引擎。</em>
+  <strong>CoDD — Coherence-Driven Development（一致性驱动开发）</strong>
 </p>
 
 <p align="center">
@@ -11,475 +10,225 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> | <a href="README_ja.md">日本語</a> | 中文
+  中文 | <a href="README.md">English</a> | <a href="README_ja.md">日本語</a>
 </p>
 
 ---
 
-> *当代码发生变更时，CoDD 追踪受影响的部分，检查违反的约束，并为你的合并决策提供完整的证据链。*
+## 只需编写功能需求和约束，CoDD 将全自动完成后续工作。
 
-```
-pip install codd-dev
-```
+CoDD 是一个开发引擎，它将 **需求 → 设计 → 实现 → 测试** 作为一张 DAG 处理，对各节点之间的一致性 (coherence) 进行机器验证，并在发现不一致时让 LLM 自动修复。
 
-## 🆕 v1.16.0-alpha — Coherence Engine（一致性驱动的中央枢纽）
-
-**通过 `DriftEvent` 统一格式连接 drift / validate / propagate / fix 的中央枢纽。**
-
-| 组件 | 作用 |
-|------|------|
-| `DriftEvent` | 包含 source/target/change_type/payload/severity/fix_strategy/kind 的统一事件类型 |
-| `EventBus` | 进程内 pub/sub。Detector publish、Orchestrator subscribe |
-| `Orchestrator` | severity 路由: `red` → auto-fix / `amber` → pending HITL / `green` → log |
-| `coherence_adapters` | drift / validate / design-token violation 输出 → DriftEvent 转换 |
-| `codd propagate --coherence` | 注入 lexicon + DESIGN.md 到 AI prompt（防止术语漂移、色值不一致） |
-| Fixer Coherence-Mode | `run_fix(coherence_event=...)` 时允许修改设计文档（test 失败修复流程保持分离） |
-
-auto-fix 失败时自动降级为 amber，记录到 `docs/coherence/pending_hitl.md` 作为待人工审查的条目。ntfy 通知带速率限制（默认 60 秒）防止通知爆炸。**现有 CLI（`codd drift` / `validate` / `propagate` / `fix`）100% 向后兼容**，不传 `--coherence` 时维持原有行为。
-
-⚠️ **alpha 版本**: Phase 4+（Detector ↔ Applier 直接配管 / `codd fixup-drift` 子命令）将在下一版本实现。本次发布为中央枢纽的架构确立阶段。
-
----
-
-## 🆕 v1.14.0 — `codd implement` 的 Batch guard
-
-`codd implement` 支持 `--max-tasks N`（默认 30）和 `--wave WAVE_ID`，可安全分批执行大型 implementation plan。**preflight task count guard** 防止 AI 失控 fan-out，并返回包含 `--wave` / `--max-tasks` / `--task` 替代方案的 actionable error message。
-
-```bash
-codd implement --max-tasks 30           # 超过 30 个则 abort
-codd implement --wave wave_2_1          # 仅执行 wave_2_1 的 tasks
-```
-
-> v1.13.1 是 `DesignTokenDriftLinker` 的 `project_root` Path 转换 bug 修复补丁。
-
----
-
-## 🆕 v1.13.0 — DESIGN.md 集成（Google Stitch OSS, W3C Design Tokens）
-
-**实现从 UI 设计到代码生成的完整可追溯性。**
-
-| 功能 | 说明 |
-|------|------|
-| `DesignMdExtractor` | 自动解析 DESIGN.md（W3C Design Tokens spec） |
-| `KnowledgeFetcher` UI 检测 | 自动识别 React/Vue/Svelte/Flutter 等并建议采用 DESIGN.md |
-| `codd implement` 注入 | 生成 UI 文件时自动将 DESIGN.md tokens 加入 AI prompt |
-| `codd validate --design-tokens` | 检测硬编码的 #hex/px 值并推荐参照 DESIGN.md |
-| `codd drift` design_token | 比对 UI 实现的 token 引用与 DESIGN.md 定义集合 |
-| `codd verify --design-md` | 集成 `npx @google/design.md lint` 到 CoDD 报告 |
-
-```yaml
-# DESIGN.md 示例（放在项目根目录）
----
-version: "1.0"
-name: "My App"
-colors:
-  Primary: "#1A73E8"
-components:
-  Button.primary:
-    background: "{colors.Primary}"
----
-```
-
-规格说明: [google-labs-code/design.md](https://github.com/google-labs-code/design.md)
-
----
-
-## 🆕 v1.12.0 — 元设计上下文层（project_lexicon）
-
-CoDD 增加 **元设计上下文层**。在 `project_lexicon.yaml` 中一次性声明项目的术语表、命名规约、设计原则后，所有 AI 命令（require / plan / generate / implement）都会自动使用。
-
-- 📖 `ProjectLexicon` — 声明节点术语、命名规约、设计原则、failure modes
-- 🌐 `KnowledgeFetcher` — Web Search 优先的知识层，30 天缓存。CoDD 核心零硬编码框架知识
-- 🔍 `codd validate --lexicon` — 检测 lexicon 内的命名规约违反
-- 🔌 Extractor registry — 通过 Python module path 声明 extractor 类。`FileSystemRouteExtractor` 是首个注册示例
-- 🧙 Lexicon wizard — `codd plan` 在 lexicon 不存在时自动生成 draft `project_lexicon.yaml`
-- 📋 `CoverageAuditor` — 需求 gap 检测，AUTO_ACCEPT / ASK / AUTO_REJECT 三分类规则
-- 🏷️ Provenance tracking — 每个 lexicon 条目带 `provenance` / `confidence` / `fetched_at`
-
----
-
-## 🆕 v1.11.0 — 文件系统路由感知的 Drift 检测
-
-CoDD 现在理解文件系统路由框架（Next.js, SvelteKit, Nuxt, Astro, Remix），可检测设计文档与实现之间的 URL drift。
-
-- 📐 `FileSystemRouteExtractor` — 从目录结构提取 endpoint 节点
-- 🔗 `DocumentUrlLinker` — 自动将设计文档的 URL 链接到 endpoint
-- 🔍 `codd drift` — 检测设计与实现的 URL gap
-- 🎨 `codd extract --layer routes` — 反向生成 screen-flow 图
-
-详细信息请参阅英文版 README 的 [Filesystem Routing Adapter Recipes](README.md#filesystem-routing-adapter-recipes)。
-
----
-
-**v1.9.0** — `codd implement` 支持**多 AI 引擎**（Claude stdout + Codex 文件写入）和**阶段内自动并行执行**（通过 git worktree 隔离）。支持阶段里程碑格式（`#### M1.1`）。重度推理模型的超时时间延长至 1 小时。SWE-bench Verified: **73/73 = 100%** 已解决。
-
----
-
-## 为什么选择 CoDD？
-
-AI 能生成规格说明书。但 **上游变更时会发生什么？**
-
-所有规格优先工具都止步于创建阶段。CoDD 从那里开始。当需求变更、代码更新或设计假设偏移时，CoDD **自动将变更向下游传播** — 更新受影响的设计文档，标记过时的制品，并生成完整的证据链。
-
-```
-需求变更 → codd impact 识别出 6 个受影响的文档
-代码变更 → codd propagate 更新下游设计
-设计变更 → CEG 图追踪所有依赖制品
-```
-
-没有其他工具能做到这一点。spec-kit、Kiro 和 cc-sdd 只负责创建文档。**CoDD 确保它们始终保持一致。**
-
-## 工作原理
-
-```
-需求（人工编写）  →  设计文档（AI 生成）  →  代码和测试（AI 生成）
-       ↕                    ↕                      ↕
-   codd impact        codd propagate          codd extract
-  （什么变了？）     （更新下游）          （逆向工程）
-```
-
-### 三层架构
-
-```
-Harness（CLAUDE.md、Hooks、Skills）   ← 规则、护栏、工作流
-  └─ CoDD（方法论）                    ← 跨变更一致性
-       └─ 设计文档（docs/*.md）        ← CoDD 管理的制品
-```
-
-CoDD **与 harness 无关** — 可与 Claude Code、Copilot、Cursor 或任何 Agent 框架配合使用。
-
-## 核心原则：推导，而非配置
-
-| 架构 | 推导出的测试策略 | 需要配置？ |
-|---|---|---|
-| Next.js + Supabase | vitest + Playwright | 无需 |
-| FastAPI + Python | pytest + httpx | 无需 |
-| Go CLI 工具 | go test | 无需 |
-
-**上游决定下游。** 你定义需求和约束，AI 推导出其余一切。
-
-## 快速开始
-
-### 全新项目（Greenfield）
+人类只需要写清楚 **“要做什么” 和 “做到什么程度”**。至于“如何实现”，交给 CoDD 与 LLM。
 
 ```bash
 pip install codd-dev
-mkdir my-project && cd my-project && git init
-
-# 初始化 — 传入需求文件，支持任意格式
-codd init --project-name "my-project" --language "typescript" \
-  --requirements spec.txt
-
-# AI 设计文档依赖图
-codd plan --init
-
-# 按波次生成设计文档
-waves=$(codd plan --waves)
-for wave in $(seq 1 $waves); do
-  codd generate --wave $wave
-done
-
-# 质量门禁 — 捕获 AI 偷懒（TODO、占位符）
-codd validate
-
-# 从设计文档生成代码
-codd implement
-
-# 组装代码片段为可构建的项目
-codd assemble
 ```
 
-### 已有项目（Brownfield）
-
-```bash
-codd extract              # 从代码逆向工程设计文档
-codd require              # 从代码推断需求（构建了什么以及为什么）
-codd plan --init          # 从提取的文档生成 wave_config
-codd scan                 # 构建依赖图
-codd impact               # 变更影响分析
-codd audit --skip-review  # 完整变更审查：验证 + 影响 + 策略
-codd measure              # 项目健康评分（0-100）
-```
-
-## 演示
-
-### 可复现的端到端演示 — 3 种传播模式
-
-以下演示固定在提交 [`d7d9f45`](https://github.com/yohey-w/codd-dev/commit/d7d9f45)，你可以在本地完整复现。
-
-**设置：**
-```bash
-pip install codd-dev>=1.6.0
-mkdir demo && cd demo && git init
-cat > spec.txt << 'EOF'
-TaskFlow — 需求
-- 用户认证（邮箱 + Google OAuth）
-- 工作区管理（团队、角色、邀请）
-- 任务 CRUD（负责人、标签、截止日期）
-- 实时更新（WebSocket）
-- 文件附件（S3）
-- 通知系统（应用内 + 邮件）
-EOF
-codd init --project-name "taskflow" --language "typescript" --requirements spec.txt
-```
-
-**模式 1 — 源 → 文档**（规格 → 设计文档）：
-```bash
-codd plan --init
-for wave in $(seq 1 $(codd plan --waves)); do codd generate --wave $wave; done
-codd validate        # 预期：PASS，0 个错误
-codd scan            # 预期：17 个节点，30+ 条边
-```
-
-**模式 2 — 文档 → 文档**（需求变更 → 下游更新）：
-```bash
-# 编辑需求：为认证模块添加 "SSO (SAML 2.0)"
-codd impact          # 预期：7 个设计文档中有 6 个在 Green/Amber 区间
-
-# 重新生成受影响的波次（propagate 仅用于代码→文档）
-codd generate --wave 1 --force   # 从更新的需求重新推导验收标准
-codd generate --wave 2 --force   # 从更新的 Wave 1 重新推导系统设计
-# 按依赖顺序对每个受影响的波次重复操作
-```
-
-**模式 3 — 文档 → 文档（通过 CEG）**（代码变更 → 设计更新）：
-```bash
-# 修改认证模块的源代码
-codd propagate       # 预期：识别出 auth-design、system-design 受影响
-codd propagate --update  # AI 根据代码差异更新受影响的设计文档
-```
-
-**预期输出**：20 行规格 → 17 个设计制品（5,100+ 行）→ 下游传播在变更后保持所有文档一致。模式 3（基于 CEG 的传播）是创新性的 — 没有其他工具能通过依赖图追踪代码变更回溯更新设计文档。
-
-### Greenfield — 从规格到可运行应用
-
-37 行规格 → 6 个设计文档（1,353 行）→ 102 个代码文件（6,445 行）→ TypeScript strict 构建通过。无需交互式 AI 对话 — 整个工作流就是一个 shell 脚本。
-
-完整教程：[Harness as Code — CoDD 指南 #1](https://zenn.dev/shio_shoppaize/articles/codd-greenfield-guide?locale=en)
-
-### Brownfield — 变更影响分析
-
-需求中修改 2 行 → `codd impact` 识别出 7 个设计文档中有 6 个受影响。Green 区间：AI 自动更新。Amber 区间：人工审查。在任何东西出问题之前，你就知道需要修复什么。
-
-深度解析：[CoDD 深度解读](https://zenn.dev/shio_shoppaize/articles/shogun-codd-coherence?locale=en)
-
-## 波次生成
-
-设计文档按依赖顺序生成 — 每个波次依赖于前一个：
-
-```
-Wave 1  验收标准 + ADR             ← 仅需求
-Wave 2  系统设计                   ← 需求 + Wave 1
-Wave 3  数据库设计 + API 设计       ← 需求 + Wave 1-2
-Wave 4  UI/UX 设计                 ← 需求 + Wave 1-3
-Wave 5  实施计划                   ← 以上全部
-```
-
-验证自底向上进行（V-Model）：
-
-```
-单元测试          ← 验证详细设计
-集成测试          ← 验证系统设计
-端到端/系统测试   ← 验证需求 + 验收标准
-```
-
-## Frontmatter = 唯一事实来源
-
-依赖关系在 Markdown 的 frontmatter 中声明。无需单独的配置文件。
-
-```yaml
 ---
-codd:
-  node_id: "design:api-design"
-  modules: ["api", "auth"]        # ← 链接到源代码模块
-  depends_on:
-    - id: "design:system-design"
-      relation: derives_from
-    - id: "req:my-project-requirements"
-      relation: implements
----
+
+## Quick Start (5 分钟)
+
+### 1. 安装
+
+```bash
+pip install codd-dev
+codd --version  # 1.34.0 或更高
 ```
 
-`modules` 字段实现反向可追溯性：当源代码变更时，`codd extract` 识别受影响的模块，`modules` 字段将这些模块映射回需要更新的设计文档。
-
-`codd/scan/` 是缓存 — 每次 `codd scan` 时重新生成。
-
-## 自定义节点前缀
-
-默认情况下，`node_id` 值必须使用内置前缀之一（`design:`、`req:`、`doc:`、`module:` 等）。要将 CoDD 用于非软件领域（知识库、审查文档、提示词管理），在 `codd.yaml` 中添加自定义前缀：
+### 2. 在项目中放置 codd.yaml
 
 ```yaml
 # codd.yaml
-prefixes:
-  - knowledge
-  - schema
-  - review
-  - prompt
+codd_required_version: ">=1.34.0"
+
+dag:
+  design_docs:
+    - "docs/design/**/*.md"
+  implementations:
+    - "src/**/*.{ts,tsx,py}"
+  tests:
+    - "tests/**/*.{spec,test}.{ts,tsx,py}"
+
+repair:
+  approval_mode: required   # 自动修复需要人工批准
+  max_attempts: 10
+
+llm:
+  ai_command: "claude"      # 可调用任意 LLM CLI (claude / codex / gemini 等)
 ```
 
-自定义前缀**与内置默认值合并** — 无需重新列出 `design`、`req` 等。前缀名称仅允许小写字母和下划线（`[a-z_]+`）。
-
-## AI 模型配置
-
-CoDD 调用外部 AI CLI 进行文档生成。默认使用 Claude Opus：
-
-```yaml
-# codd.yaml
-ai_command: "claude --print --model claude-opus-4-6"
-```
-
-### 按命令覆盖
-
-不同命令可以使用不同模型。例如，使用 Opus 生成设计文档，使用 Codex 实现代码：
-
-```yaml
-ai_command: "claude --print --model claude-opus-4-6"   # 全局默认
-ai_commands:
-  generate: "claude --print --model claude-opus-4-6"    # 设计文档生成
-  restore: "claude --print --model claude-opus-4-6"     # brownfield 重建
-  review: "claude --print --model claude-opus-4-6"      # 质量评审
-  plan_init: "claude --print --model claude-sonnet-4-6" # wave_config 规划
-  implement: "codex --print"                             # 代码生成
-```
-
-**优先级**：CLI `--ai-cmd` 参数 > `ai_commands.{command}` > `ai_command` > 内置默认值（Opus）。
-
-## 命令
-
-| 命令 | 状态 | 描述 |
-|---------|--------|-------------|
-| `codd init` | **稳定** | 在任何项目中初始化 CoDD |
-| `codd scan` | **稳定** | 从 frontmatter 构建依赖图 |
-| `codd impact` | **稳定** | 变更影响分析（Green / Amber / Gray） |
-| `codd validate` | **Alpha** | Frontmatter 完整性和图一致性检查 |
-| `codd generate` | 实验性 | 按波次顺序生成设计文档（greenfield） |
-| `codd restore` | 实验性 | 从提取的事实重建设计文档（brownfield） |
-| `codd plan` | 实验性 | 波次执行状态（`--init` 支持 brownfield 回退） |
-| `codd verify` | 实验性（Pro） | V-Model 验证 |
-| `codd implement` | 实验性 | 设计到代码生成 |
-| `codd propagate` | **Alpha** | 将代码/文档变更向下游传播到受影响的设计文档 |
-| `codd review` | 实验性（Pro） | AI 驱动的制品质量评估（LLM-as-Judge） |
-| `codd extract` | **Alpha** | 从现有代码逆向工程设计文档 |
-| `codd require` | **Alpha** | 从现有代码库推断需求（brownfield） |
-| `codd audit` | **Alpha**（Pro） | 综合变更审查包（验证 + 影响 + 策略 + 评审） |
-| `codd policy` | **Alpha** | 企业策略检查器（源代码中的禁止/必需模式） |
-| `codd measure` | **Alpha** | 项目健康度量（图、覆盖率、质量、健康评分 0-100） |
-| `codd mcp-server` | **Alpha** | 用于 AI 工具集成的 MCP 服务器（stdio，零依赖） |
-
-## OSS / Pro 划分
-
-CoDD v1.6.0 通过桥接模式引入了清晰的 OSS/Pro 边界。
-
-**OSS（MIT，免费）** — 保持文档一致性所需的一切：
-
-`init` · `scan` · `impact` · `generate` · `restore` · `propagate` · `extract` · `require` · `plan` · `validate` · `measure` · `policy` · `mcp-server`
-
-**Pro（私有，付费）** — 企业级审查和验证：
-
-`review` · `verify` · `audit` · `risk`
+### 3. 常用命令
 
 ```bash
-# 仅 OSS
-pip install codd-dev
+# 一致性验证（检查需求、设计、实现、测试之间的一致性）
+codd dag verify
 
-# 添加 Pro 扩展
-pip install "codd-pro @ git+ssh://git@github.com/yohey-w/codd-pro.git"
+# 带自动修复的验证（发现违规后由 LLM 生成并应用 patch）
+codd dag verify --auto-repair --max-attempts 10
+
+# User Journey 的真实浏览器 PASS 验证（通过 CDP 操作浏览器）
+codd dag run-journey login_to_dashboard --axis viewport=smartphone_se
+
+# 从设计文档导出实现步骤（实现阶段的输入）
+codd implement run --task M1.2 --enable-typecheck-loop
 ```
 
-当 `codd-pro` 已安装时，Pro 实现通过 entry-points 插件发现自动覆盖 OSS 回退。未安装时，Pro 命令显示迁移提示并正常退出。无需额外配置。
+### 4. 如何阅读输出
 
-## CI 集成（GitHub Action）
+`codd dag verify` 会运行 9 类 coherence check：
 
-在每个 Pull Request 上运行 CoDD 审计。该 Action 会发布评论，包含裁定（APPROVE / CONDITIONAL / REJECT）、验证结果、策略违规和影响分析。
+| Check | 作用 |
+|-------|------|
+| `node_completeness` | 设计文档中声明的节点（实现/测试）是否作为物理文件存在 |
+| `transitive_closure` | 需求 → 设计 → 实现 → 测试的依赖链是否闭合 |
+| `verification_test_runtime` | 针对实现的测试是否可执行并 PASS |
+| `deployment_completeness` | 部署链（Dockerfile/compose/k8s）是否完备 |
+| `proof_break_authority` | 关键 journey 是否没有被破坏 |
+| `screen_flow_edges` | 画面跳转图中是否没有孤立节点 |
+| `screen_flow_completeness` | 所有画面是否都映射到需求 |
+| `c8` | 检测 uncommitted patch / dirty file |
+| `c9` (`environment_coverage`) | viewport / RBAC role / locale 等 **目标环境覆盖率** |
 
-### 快速设置
+发现 violation 时会阻断 deploy gate；使用 `--auto-repair` 时，会进入 LLM patch 生成 → 应用 → 再验证的循环。
 
-在你的项目中添加 `.github/workflows/codd.yml`：
+---
+
+## 典型用例
+
+### 用例 1：需求 → 设计 → 实现自动化
+
+在 `docs/requirements/*.md` 中编写“功能需求 + 约束”，再调用 `codd implement run`：
+
+1. LLM 会从需求动态导出 ImplStep 列表 (Layer 1)
+2. 补全最佳实践 (Layer 2，例如登录 → 登出/Remember Me/会话超时等)
+3. 经过用户批准 (HITL gate) 后，在 `src/**` 中生成实现
+4. 生成过程中若 `tsc` 等 type check 失败，则进入自动修复循环
+
+人类可以体验到“只写功能需求 + 约束，其余全自动”的工作流。
+
+### 用例 2：Auto-Repair (codd verify --auto-repair)
+
+在 CI 中运行 `codd dag verify --auto-repair --max-attempts 10`：
+
+1. 执行 9 类 coherence check
+2. 通过 Hybrid Classifier (git diff + LLM) 将 violation 分类为 **可修复 (in-task) / 既存问题 (baseline) / 不可修复 (unrepairable)**
+3. 从可修复 violation 中选出 DAG 上最上游的一项，由 LLM 生成 patch
+4. 经过 dry-run validation 后 apply，并再次验证
+5. 在 max_attempts 内全部解决 → `SUCCESS`，部分修复 → `PARTIAL_SUCCESS`，几乎都是不可修复 → `REPAIR_FAILED`
+
+即便结果为 `PARTIAL_SUCCESS`，已修复的 patch 仍会被反映，残留 violation 会列在 report 中以保证透明性。
+
+### 用例 3：User Journey Coherence (codd dag run-journey)
+
+在 `docs/design/auth_design.md` 的 frontmatter 中编写用户旅程：
 
 ```yaml
-name: CoDD Audit
-on:
-  pull_request:
-    branches: [main]
-
-permissions:
-  contents: read
-  pull-requests: write
-
-jobs:
-  audit:
-    runs-on: ubuntu-latest
+user_journeys:
+  - name: login_to_dashboard
+    criticality: critical
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: yohey-w/codd-dev@main
-        with:
-          diff-target: origin/${{ github.base_ref }}
-          skip-review: "true"  # 设置为 "false" 启用 AI 审查
+      - { action: navigate, target: "/login" }
+      - { action: fill, selector: "input[type=email]", value: "user@example.com" }
+      - { action: click, selector: "button[type=submit]" }
+      - { action: expect_url, value: "/dashboard" }
 ```
 
-## 与其他规格驱动工具的区别
+执行 `codd dag run-journey login_to_dashboard --axis viewport=smartphone_se` 后：
 
-所有主流规格驱动工具都专注于**创建**设计文档。没有一个解决文档**变更后**会发生什么的问题。CoDD 通过依赖图、影响分析和分区更新协议填补了这个空白。
+- 将 `project_lexicon.yaml` 中声明的 `viewport=smartphone_se` (375x667) 注入到 CDP runtime
+- 使用真实浏览器 (Edge / Chrome) 执行 journey
+- 失败时，`codd dag verify` 的 C9 environment_coverage 会阻断 deploy gate
 
-| | **spec-kit**（GitHub） | **Kiro**（AWS） | **cc-sdd**（gotalab） | **CoDD** |
-|--|---|---|---|---|
-| 重点 | 规格创建 | 集成 SDD 的 IDE | Claude Code 的 Kiro 风格 SDD | **创建后的一致性维护** |
-| 变更传播 | 否 | 否 | 否 | **`codd impact` + 依赖图** |
-| 影响分析 | 否 | 否 | 否 | **Green / Amber / Gray 分区** |
-| Harness 锁定 | GitHub Copilot | Kiro IDE | Claude Code | **任何 Agent / IDE** |
+这样可以结构性地防止“只在手机端导航消失”等事故。
 
-简而言之：spec-kit、Kiro 和 cc-sdd 回答的是*"如何创建规格？"* CoDD 回答的是*"当上游发生变更时，如何自动更新所有下游？"*
+---
 
-## SWE-bench 验证
+## v1.34.0 主要功能
 
-CoDD 在 SWE-bench Lite（真实开源项目的 bug 修复基准）上进行了验证。在 brownfield 场景下——给定一个现有代码库和需要修复的 bug——CoDD 的设计文档提取和自主修复循环实现了显著的改善：
+| 功能 | 作用 |
+|------|------|
+| **DAG 完整性** (C1〜C8) | 对需求、设计、实现、测试、部署执行 9 类 coherence check |
+| **Coverage Axis Layer** (C9) | 使用统一抽象（支持 16+ 轴）验证 viewport / RBAC role / locale 等 **目标环境覆盖率** |
+| **LLM Auto-Repair (RepairLoop)** | violation 检测 → LLM patch 生成 → apply → 再验证，在 `max_attempts` 内尝试全部解决 |
+| **Hybrid Classifier** | 通过 git diff (Stage 1) + LLM 判断 (Stage 2) 将 violation 分类为 repairable / pre_existing / unrepairable |
+| **Primary Picker** | 在多个 violation 中优先修复 DAG 上最上游的一项（root cause 候选） |
+| **PARTIAL_SUCCESS policy** | 只要存在 applied_patches OR pre_existing OR unrepairable 即为 PARTIAL_SUCCESS，可避免 CI 成为 release blocker |
+| **BestPracticeAugmenter** | 由 LLM 动态补全设计文档未明写的最佳实践（如密码重置等） |
+| **ImplStepDeriver (2-layer)** | 从设计文档动态展开 ImplStep 列表，并在 Layer 2 推断 `required_axes` |
+| **Typecheck Repair Loop** | 实现阶段若 `tsc --noEmit` 等 type check 失败，则进入自动修复循环 |
+| **`codd version --check --strict`** | 检测项目要求版本与已安装 codd 版本之间的差异 |
 
-| 阶段 | 方法 | 解决率 |
-|---|---|---|
-| 单次尝试（Phase 1） | CoDD extract + Claude Opus 4.6 | 57.5% |
-| 单次尝试（Phase 1） | CoDD extract + GPT-5.4 | 60.3% |
-| 自主循环（Phase 2） | Phase 1 失败 → DIVERGENT 策略重试 | *进行中* |
-| 30 题试点 | 自主循环 v2 | 90.0% |
+详情请参阅 [CHANGELOG.md](CHANGELOG.md)。
 
-Phase 2 使用 DIVERGENT 策略：当同一类型连续失败 2 次后，强制切换假设方向。这实现了从 60% → 90% 的跳跃——不是靠对基准测试过拟合，而是靠系统性地探索不同的修复假设。
+---
 
-## 实际使用
+## 实证案例研究 — osato-lms (LMS Web App)
 
-在生产 Web 应用上经过实战检验 — 18 个设计文档通过依赖图连接。所有文档、代码和测试都由 AI 按照 CoDD 生成。当项目中期需求变更时，`codd impact` 识别了受影响的制品，AI 自动修复了它们。
+在内部 LMS 项目 osato-lms (Next.js + Prisma + PostgreSQL) 上执行 `codd verify --auto-repair --max-attempts 10`，结果如下：
 
-### CoDD 管理自身的开发
-
-CoDD 使用自身进行开发（吃自己的狗粮）。`.codd/` 目录包含 CoDD 自己的配置，`codd extract` 从自己的源代码逆向工程设计文档：
-
-```bash
-codd init --config-dir .codd --project-name "codd-dev" --language "python"
-codd extract          # 15 个模块 → 带依赖 frontmatter 的设计文档
-codd scan             # 49 个节点，83 条边
-codd verify           # mypy + pytest（434 个测试通过）
+```
+status:                PARTIAL_SUCCESS
+attempts:              4
+applied_patches:       4
+pre_existing_violations:  1
+unrepairable_violations:  2
+remaining_violations:     3 (skip + report 已完成)
+smoke proof:           6 checks PASS
+CoDD core 修改:        0 行
 ```
 
-如果 CoDD 管理不了自己，它也不应该管理你的项目。
+被修复的文件：
+- `tests/e2e/environment-coverage.spec.ts`
+- `tests/e2e/login.spec.ts`
 
-## 文章
+被跳过的 violation（作为 CoDD 责任范围外的问题在 report 中明确记录）：
+- pre_existing: deployment_completeness chain
+- unrepairable: Dockerfile dry-run patch validation
+- unrepairable: Vitest matcher runtime issue
 
-- [dev.to: Harness as Code — 像基础设施一样对待 AI 工作流](https://dev.to/yohey-w/harness-as-code-treating-ai-workflows-like-infrastructure-27ni)
-- [dev.to: "规格优先"之后会发生什么](https://dev.to/yohey-w/codd-coherence-driven-development-what-happens-after-spec-first-514f)
-- [Zenn: Harness as Code — CoDD 指南 #1 规格 → 设计 → 代码](https://zenn.dev/shio_shoppaize/articles/codd-greenfield-guide?locale=en)
-- [Zenn: Harness as Code — CoDD 指南 #2 Brownfield](https://zenn.dev/shio_shoppaize/articles/shogun-codd-brownfield?locale=en)
-- [Zenn: Harness as Code — CoDD 指南 #3 使用 CoDD extract 修复 Bug（SWE-bench）](https://zenn.dev/shio_shoppaize/articles/codd-swebench-pilot?locale=en)
-- [Zenn: CoDD 深度解读](https://zenn.dev/shio_shoppaize/articles/shogun-codd-coherence?locale=en)
+C9 environment_coverage 验证了 viewport (smartphone_se / desktop_1920) 与 RBAC role (central_admin / tenant_admin / learner) 的 axis × variant 全覆盖，并最终 PASS。
 
-## 赞助
+---
 
-<a href="https://github.com/sponsors/yohey-w">
-  <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?style=for-the-badge&logo=github-sponsors" alt="Sponsor">
-</a>
+## 架构 — 4 个 release 的演进
 
-您的赞助让 CoDD 持续免费并推动开发。查看[赞助等级](https://github.com/sponsors/yohey-w)。
+| Release | 达成状态 |
+|---------|----------|
+| v1.31.0 | 内侧 100%（内部一致性 coherence）— 通过 type check repair loop 消灭“手动 type fix” |
+| v1.32.0 | 外侧 100%（目标环境覆盖率 Coverage Axis）— 以统一抽象吸收 viewport/RBAC/locale 等 |
+| v1.33.0 | caveats 解决路径实证 — 真实 CDP run-journey + LLM auto-repair attempt PASS |
+| **v1.34.0** | **full pipeline 完全实证** — 在真实项目中 auto-repair PARTIAL_SUCCESS 完整跑通 |
+
+各 release 详情请参阅 [CHANGELOG.md](CHANGELOG.md)。
+
+---
+
+## Generality Gate（绝对保持通用性）
+
+CoDD core code 中 **禁止** 以下 hardcode：
+
+- 特定 stack 名称 (Next.js / Django / Rails / FastAPI 等)
+- 特定 framework / library 的 literal
+- 特定 domain (Web / Mobile / Desktop / CLI / Backend / Embedded)
+- 特定 viewport 值 (375 / 1920 等) 或 device 名称 (iPhone / Android 等)
+
+这些内容全部封装在 **`project_lexicon.yaml`（项目固有）** 中。CoDD 只把它们作为 generic violation object 处理。
+
+当 LLM 提出“针对特定 stack 的最佳 patch”时，该判断交由 **LLM 的知识** 完成，CoDD core 不做决定（也就是不过度拟合）。
+
+---
 
 ## 许可证
 
-MIT
+MIT License — 参阅 [LICENSE](LICENSE)。
+
+## 链接
+
+- [CHANGELOG.md](CHANGELOG.md) — 全部 release notes
+- [GitHub Sponsors](https://github.com/sponsors/yohey-w) — 支持开发
+- [Issues](https://github.com/yohey-w/codd-dev/issues) — Bug 报告 / 功能请求
+
+---
+
+> “当代码发生变化时，CoDD 会追踪影响范围，检测 violation，并为合并判断生成证据。”


### PR DESCRIPTION
## Summary

CoDD v1.34.0「実用到達点 100% (真) 記念マイルストーン」に合わせて公開ドキュメントを 3 言語で全面刷新。CHANGELOG.md は各 release 時に追記済 (v1.30.0〜v1.34.0)、本 PR は README 3 言語の整合更新が中心。

### 3 commits

| 言語 | Commit | 概要 |
|------|--------|------|
| 🇯🇵 日本語 (正本) | \`76255ff\` | README_ja.md 全面刷新 (+139/-729 = -590 行 net) — 殿哲学冒頭 + Quick Start 5 分 + 9 種 coherence check + 典型ユースケース 3 つ + v1.34.0 主要機能 + osato-lms 実証ケース + 4 release 進化テーブル + Generality Gate 明記 |
| 🇨🇳 中国語 | \`f1a4e3e\` | README_zh.md を日本語正本ベースで翻訳 — 中国語読者向けに自然な表現で再構成 |
| 🇺🇸 英語 | \`f73ffab\` | README.md を日本語正本ベースで翻訳 — 国際 OSS コミュニティ向けに整理 |

### 主要記載内容 (3 言語共通)

1. **冒頭キャッチ**: 「機能要件 + 制約だけ書けば全自動」(殿哲学)
2. **Quick Start 5 分**: pip install + codd.yaml 最小設定 + 典型コマンド 4 本
3. **9 種 coherence check** テーブル (C1〜C9 全網羅、C9 environment_coverage を含む)
4. **典型ユースケース 3 つ**: 要件→設計→実装自動化 / Auto-Repair / User Journey Coherence
5. **v1.34.0 主要機能 10 項目**: DAG完全性 / Coverage Axis Layer / RepairLoop / Hybrid Classifier / Primary Picker / PARTIAL_SUCCESS policy / BestPracticeAugmenter / ImplStepDeriver / Typecheck Repair Loop / version --check
6. **osato-lms 実証ケーススタディ**: PARTIAL_SUCCESS / attempts=4 / applied=4 / pre_existing=1 / unrepairable=2 / smoke 6 PASS / CoDD core 改修 0 行
7. **4 release 進化**: v1.31 内側 → v1.32 外側 → v1.33 経路 → v1.34 完全実証
8. **Generality Gate**: stack/framework/domain hardcode 禁止を明記

### 禁止事項遵守

- 内部事情 (shogun/karo/ashigaru の役割) は記載なし — 読者視点
- specific stack 名 hardcode 禁止 (CoDD core の説明部分のみ)
- 「詳細は別ファイル参照」で逃げない — 5 分で動かせる情報を完結

### CHANGELOG.md

v1.30.0〜v1.34.0 全 release entry は各 release 時 (本日中に複数 release) に既に追記済のため、本 PR では変更なし。

## 殿レビュー依頼

- 3 言語の読者体験 (5 分で動かせるか、メッセージが伝わるか) 確認をお願いします
- osato-lms 実証ケースは「結果と数値のみ、CoDD 採用判断材料として有効か」観点
- Generality Gate 明記の表現が「OSS 利用者にも CoDD 思想が伝わる」レベルか