### PR TITLE
fix(ci): handle missing codd audit output gracefully

### DIFF
--- a/.github/workflows/codd-audit.yml
+++ b/.github/workflows/codd-audit.yml
@@ -30,11 +30,17 @@ jobs:
           set +e
           codd audit --diff origin/${{ github.base_ref }} --skip-review --json --output /tmp/codd-audit.json
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
-          set -e
 
-          # Extract verdict for summary
-          VERDICT=$(python3 -c "import json; print(json.load(open('/tmp/codd-audit.json'))['verdict'])")
+          # Extract verdict only if output file was written (audit may not produce output
+          # when no design-doc changes are detected or when the audit plugin is unavailable)
+          if [ -f /tmp/codd-audit.json ]; then
+            VERDICT=$(python3 -c "import json; print(json.load(open('/tmp/codd-audit.json'))['verdict'])")
+          else
+            VERDICT="SKIPPED"
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+          fi
           echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+          set -e
 
       - name: Generate PR Comment
         if: always()
@@ -157,4 +163,9 @@ jobs:
 
       - name: Set exit code
         if: always()
-        run: exit ${{ steps.audit.outputs.exit_code }}
+        run: |
+          VERDICT="${{ steps.audit.outputs.verdict }}"
+          if [ "$VERDICT" = "SKIPPED" ]; then
+            exit 0
+          fi
+          exit ${{ steps.audit.outputs.exit_code }}


### PR DESCRIPTION
## Summary

- `codd audit` exits without writing `/tmp/codd-audit.json` when no design-doc changes are detected (README-only PRs) or when the audit plugin is unavailable
- The workflow then failed with `FileNotFoundError` on the `VERDICT=$(python3 ...)` line, blocking all PRs with CI failure

## Root Cause

`codd/audit.py` was moved to Pro-only in `1810097`. Without the Pro plugin, `get_command_handler("audit")` returns `None` → `SystemExit(1)` → no JSON output → `FileNotFoundError` in the next shell line (after `set -e`).

## Fix

- Added `[ -f /tmp/codd-audit.json ]` guard before `VERDICT` extraction
- If file is absent: set `verdict=SKIPPED`, `exit_code=0`
- `Set exit code` step exits 0 when verdict is `SKIPPED`

## Affected PRs

- PR #15 (README 3-lang update) — already merged but CI was red
- PR #11 (Seika86 sprint heading fix) — still open, will become green after this merge

## Test plan

- [ ] Merge this PR → CI on PR #11 should turn green
- [ ] Design-doc-changing PR should still produce full audit report (non-SKIPPED path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)