### PR TITLE
[codex] Fix runtime verification targeting

### DIFF
--- a/codd/deployment/extractor.py
+++ b/codd/deployment/extractor.py
@@ -859,7 +859,8 @@ def _journey_name(journey: dict[str, Any]) -> str | None:
 
 
 def _verification_target_for_journey(journey: dict[str, Any], fallback: str) -> str:
-    for step in _as_list(journey.get("steps")):
+    steps = journey.get("cdp_steps") if isinstance(journey.get("cdp_steps"), list) else journey.get("steps")
+    for step in _as_list(steps):
         if not isinstance(step, dict):
             continue
         target = step.get("target") or step.get("url") or step.get("path")

--- a/codd/deployment/providers/verification/cdp_browser.py
+++ b/codd/deployment/providers/verification/cdp_browser.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import json
 import importlib.util
+import os
 import subprocess
 import time
 from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
+from urllib.parse import urljoin, urlparse
 
 import yaml
 
@@ -96,6 +98,7 @@ class CdpBrowser(VerificationTemplate):
             config = self._resolve_config(plan)
             timeout_seconds = _float_config(config, "timeout_seconds", 60.0)
             step_timeout = _float_config(config, "step_timeout_seconds", timeout_seconds)
+            base_url = _base_url(plan, config)
 
             browser_config = _mapping(config.get("browser"))
             launcher_config = _mapping(config.get("launcher"))
@@ -135,7 +138,7 @@ class CdpBrowser(VerificationTemplate):
 
             steps = _steps(plan)
             for index, step in enumerate(steps, start=1):
-                step_result = self._dispatch_step(wire, form_strategy, index, step, step_timeout)
+                step_result = self._dispatch_step(wire, form_strategy, index, step, step_timeout, base_url)
                 if step_result is not None:
                     result = step_result
                     return result
@@ -205,6 +208,7 @@ class CdpBrowser(VerificationTemplate):
         index: int,
         step: Mapping[str, Any],
         timeout: float,
+        base_url: str | None,
     ) -> VerificationResult | None:
         action = str(step.get("action", "")).strip()
         if not action:
@@ -217,6 +221,7 @@ class CdpBrowser(VerificationTemplate):
                 target = str(step.get("target") or step.get("url") or "")
                 if not target:
                     return VerificationResult(False, f"step {index} failed: navigate target is required")
+                target = _resolve_navigation_target(target, base_url)
                 wire.send_command("Page.navigate", {"url": target}, timeout=timeout)
                 return None
             if action == _POINTER_ACTIVATE_ACTION:
@@ -461,6 +466,27 @@ def _steps(plan: Mapping[str, Any]) -> list[Mapping[str, Any]]:
             raise ValueError("journey step must be an object")
         normalized.append(step)
     return normalized
+
+
+def _base_url(plan: Mapping[str, Any], config: Mapping[str, Any]) -> str | None:
+    env_name = str(config.get("base_url_env") or "CODD_CDP_BASE_URL")
+    value = os.environ.get(env_name) or config.get("base_url") or config.get("origin") or plan.get("base_url")
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _resolve_navigation_target(target: str, base_url: str | None) -> str:
+    text = target.strip()
+    parsed = urlparse(text)
+    if parsed.scheme:
+        return text
+    if not text.startswith("/"):
+        return text
+    if not base_url:
+        raise ValueError("relative navigate target requires cdp_browser.base_url")
+    return urljoin(base_url.rstrip("/") + "/", text.lstrip("/"))
 
 
 def _mapping(value: Any) -> dict[str, Any]:

--- a/codd/deployment/providers/verification/playwright.py
+++ b/codd/deployment/providers/verification/playwright.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import subprocess
+import shlex
 import time
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -41,20 +43,29 @@ def _project_root(runtime_state: Any) -> Path:
 class PlaywrightTemplate(VerificationTemplate):
     """Generate and execute Playwright verification commands."""
 
-    def __init__(self, timeout: float | None = None) -> None:
-        self.timeout = timeout if timeout is not None else _load_timeout_seconds()
+    def __init__(self, timeout: float | None = None, config: Mapping[str, Any] | None = None) -> None:
+        config_map = dict(config) if isinstance(config, Mapping) else {}
+        configured_timeout = _positive_float(config_map.get("timeout"))
+        self.timeout = timeout if timeout is not None else configured_timeout or _load_timeout_seconds()
+        self.project = _optional_string(config_map.get("project"))
 
     def generate_test_command(self, runtime_state, test_kind: str) -> str:
         kind = test_kind.lower()
-        test_dir = "tests/e2e/" if kind == "e2e" else "tests/smoke/"
-        parts = ["npx", "playwright", "test", test_dir, "--reporter=line"]
+        project_root = _project_root(runtime_state)
+        test_target = _specific_test_target(runtime_state, kind, project_root)
+        specific_target = test_target is not None
+        if test_target is None:
+            test_target = "tests/e2e/" if kind == "e2e" else "tests/smoke/"
+        parts = ["npx", "playwright", "test", shlex.quote(test_target), "--reporter=line"]
 
-        config_path = _project_root(runtime_state) / "playwright.config.ts"
+        config_path = project_root / "playwright.config.ts"
         if config_path.exists():
-            parts.extend(["--config", str(config_path)])
+            parts.extend(["--config", shlex.quote(str(config_path))])
+        if self.project:
+            parts.extend(["--project", shlex.quote(self.project)])
 
         target = str(getattr(runtime_state, "target", "") or "")
-        if kind == "smoke" and "login" in target.lower():
+        if not specific_target and kind == "smoke" and "login" in target.lower():
             parts.extend(["--grep", "login"])
 
         return " ".join(parts)
@@ -89,3 +100,40 @@ class PlaywrightTemplate(VerificationTemplate):
         else:
             pattern = "tests/smoke/**/*.test.ts"
         return sorted(project_root.glob(pattern))
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _positive_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _specific_test_target(runtime_state: Any, test_kind: str, project_root: Path) -> str | None:
+    source = getattr(runtime_state, "source", None)
+    if not source:
+        return None
+    source_text = str(source).strip()
+    if not source_text:
+        return None
+    expected_prefix = "tests/e2e/" if test_kind == "e2e" else "tests/smoke/"
+    normalized = source_text.replace("\\", "/")
+    if not normalized.startswith(expected_prefix):
+        return None
+
+    path = Path(source_text)
+    candidate = path if path.is_absolute() else project_root / path
+    if not candidate.is_file():
+        return None
+    try:
+        return candidate.relative_to(project_root).as_posix()
+    except ValueError:
+        return str(candidate)

--- a/codd/generator.py
+++ b/codd/generator.py
@@ -516,6 +516,7 @@ def _build_generation_prompt(
                 "- Quality gate: Define pass criteria — all PASS, zero SKIP, acceptance criteria coverage, and any release-blocking constraints from conventions.",
                 "- Output file mapping: Specify a table mapping each domain to its output file path under `tests/e2e/`.",
                 "- Shared helpers: Mandate a `tests/e2e/helpers/` directory for auth flows, test data setup, and common assertions to avoid duplication across spec files.",
+                "- Mutating test data: Any E2E scenario that creates or updates records MUST use per-run unique identifiers and explicit cleanup/idempotent teardown so repeated runs cannot fail from stale data or uniqueness constraints.",
                 "- Generation markers: All generated files must include `// @generated-from:` and `// @generated-by: codd propagate` headers. Manual tests marked with `// @manual` must be preserved on regeneration.",
                 "",
                 "E2E Test Level Separation (CRITICAL):",

--- a/codd/implementer.py
+++ b/codd/implementer.py
@@ -1095,6 +1095,7 @@ def _build_implementation_prompt(
         f"- Generate concrete production-oriented {language_name} source files.",
         framework_guidance,
         "- Reflect security, data boundaries, authentication, authorization, and auditability explicitly where the design requires them.",
+        "- For UI files or user-facing strings, write production user copy only; never surface design rationale, test/demo/sample labels, implementation assumptions, TODOs, internal process, or environment notes as visible text.",
         "- The tool will prepend traceability comments to each generated file; do not emit separate metadata files.",
         "- Do not emit prose, explanations, Markdown headings, YAML, TODOs, placeholders, or file descriptions outside the required FILE blocks.",
         "- Every generated file path must stay under one of the output paths shown above.",

--- a/codd/repair/verify_runner.py
+++ b/codd/repair/verify_runner.py
@@ -53,6 +53,7 @@ class _RuntimeVerificationState:
     identifier: str
     target: str
     project_root: Path
+    source: str | None = None
     actual_check_command: str | None = None
     journey: dict[str, Any] | None = None
     steps: list[Any] = field(default_factory=list)
@@ -270,12 +271,13 @@ def _runtime_state(node: Any, project_root: Path, template_config: dict[str, Any
     attributes = dict(getattr(node, "attributes", {}) or {})
     expected = attributes.get("expected_outcome") if isinstance(attributes.get("expected_outcome"), dict) else {}
     journey = expected.get("journey") if isinstance(expected.get("journey"), dict) else None
-    steps = journey.get("steps") if isinstance(journey, dict) and isinstance(journey.get("steps"), list) else []
+    steps = _journey_steps(journey)
     target = attributes.get("target") or expected.get("target") or _journey_target(journey)
     return _RuntimeVerificationState(
         identifier=str(attributes.get("identifier") or getattr(node, "id", "")),
         target=str(target or ""),
         project_root=project_root,
+        source=_optional_string(attributes.get("source") or expected.get("source")),
         actual_check_command=_optional_string(attributes.get("actual_check_command") or expected.get("actual_check_command")),
         journey=journey,
         steps=steps,
@@ -283,17 +285,25 @@ def _runtime_state(node: Any, project_root: Path, template_config: dict[str, Any
     )
 
 
+def _journey_steps(journey: dict[str, Any] | None) -> list[Any]:
+    if not isinstance(journey, dict):
+        return []
+    cdp_steps = journey.get("cdp_steps")
+    if isinstance(cdp_steps, list):
+        return cdp_steps
+    steps = journey.get("steps")
+    return steps if isinstance(steps, list) else []
+
+
 def _journey_target(journey: dict[str, Any] | None) -> str:
     if not isinstance(journey, dict):
         return ""
-    steps = journey.get("steps")
-    if isinstance(steps, list):
-        for step in steps:
-            if not isinstance(step, dict) or step.get("action") != "navigate":
-                continue
-            target = step.get("target") or step.get("url")
-            if target:
-                return str(target)
+    for step in _journey_steps(journey):
+        if not isinstance(step, dict) or step.get("action") != "navigate":
+            continue
+        target = step.get("target") or step.get("url")
+        if target:
+            return str(target)
     return str(journey.get("target") or journey.get("url") or "")
 
 

--- a/tests/deployment/test_cdp_browser_core.py
+++ b/tests/deployment/test_cdp_browser_core.py
@@ -312,6 +312,35 @@ def test_cdp_browser_execute_dispatches_full_journey():
     assert wire.closed is True
 
 
+def test_cdp_browser_resolves_relative_navigation_with_base_url():
+    _register_mock_plugins(launch_command=[], teardown_command=[])
+    wire = RecordingWire()
+    config = _config()
+    config["base_url"] = "https://example.test"
+
+    result = CdpBrowser(config=config, wire_factory=lambda: wire, sleep=lambda _: None).execute(
+        json.dumps({"steps": [{"action": "navigate", "target": "/login"}]})
+    )
+
+    assert result.passed is True
+    assert wire.commands == [("Page.navigate", {"url": "https://example.test/login"}, 0.5)]
+
+
+def test_cdp_browser_base_url_env_overrides_config(monkeypatch):
+    _register_mock_plugins(launch_command=[], teardown_command=[])
+    wire = RecordingWire()
+    config = _config()
+    config["base_url"] = "https://config.example.test"
+    monkeypatch.setenv("CODD_CDP_BASE_URL", "https://env.example.test")
+
+    result = CdpBrowser(config=config, wire_factory=lambda: wire, sleep=lambda _: None).execute(
+        json.dumps({"steps": [{"action": "navigate", "target": "/login"}]})
+    )
+
+    assert result.passed is True
+    assert wire.commands == [("Page.navigate", {"url": "https://env.example.test/login"}, 0.5)]
+
+
 def test_cdp_browser_loads_project_config_from_codd_yaml(tmp_path: Path):
     _register_mock_plugins(launch_command=[], teardown_command=[])
     wire = RecordingWire()

--- a/tests/repair/test_verify_runner.py
+++ b/tests/repair/test_verify_runner.py
@@ -225,6 +225,47 @@ def test_verify_runner_executes_cdp_browser_template_by_python_import(tmp_path, 
     assert calls[1]["command"] == "journey-command"
 
 
+def test_verify_runner_prefers_cdp_steps_over_conceptual_journey_steps(tmp_path, monkeypatch):
+    class FakeCdpBrowser:
+        def __init__(self, config=None):
+            self.config = config
+
+        def generate_test_command(self, runtime_state, test_kind: str) -> str:
+            assert runtime_state.source == "tests/e2e/login.spec.ts"
+            assert runtime_state.steps == [{"action": "navigate", "target": "/login"}]
+            return "journey-command"
+
+        def execute(self, command: str) -> ProviderVerificationResult:
+            return ProviderVerificationResult(True, "journey ok")
+
+    dag = _dag(
+        Node(
+            "verification:cdp_browser:login",
+            "verification_test",
+            attributes={
+                "kind": "e2e",
+                "template_ref": "cdp_browser",
+                "expected_outcome": {
+                    "source": "tests/e2e/login.spec.ts",
+                    "journey": {
+                        "steps": [{"action": "login", "role": "admin"}],
+                        "cdp_steps": [{"action": "navigate", "target": "/login"}],
+                    },
+                },
+            },
+        )
+    )
+    _patch_verify_pipeline(monkeypatch, dag, [])
+    monkeypatch.setitem(verify_runner_module.VERIFICATION_TEMPLATES, "cdp_browser", FakeCdpBrowser)
+
+    result = VerifyRunner(
+        tmp_path,
+        {"verification": {"templates": {"cdp_browser": {"browser": {"engine": "fake"}}}}},
+    ).run()
+
+    assert result.passed is True
+
+
 def test_verify_runner_runtime_failure_becomes_verification_failure(tmp_path, monkeypatch):
     class FailingTemplate:
         def generate_test_command(self, runtime_state, test_kind: str) -> str:

--- a/tests/test_deployment_verification_templates.py
+++ b/tests/test_deployment_verification_templates.py
@@ -44,6 +44,51 @@ def test_playwright_generate_test_command_e2e(tmp_path, monkeypatch):
     assert command == "npx playwright test tests/e2e/ --reporter=line"
 
 
+def test_playwright_generate_test_command_prefers_verification_source_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    spec_path = tmp_path / "tests" / "e2e" / "login.spec.ts"
+    spec_path.parent.mkdir(parents=True)
+    spec_path.write_text("test('login', () => {})", encoding="utf-8")
+
+    class RuntimeState:
+        project_root = tmp_path
+        source = "tests/e2e/login.spec.ts"
+        target = "/login"
+
+    command = PlaywrightTemplate().generate_test_command(RuntimeState(), "e2e")
+
+    assert command == "npx playwright test tests/e2e/login.spec.ts --reporter=line"
+
+
+def test_playwright_source_file_does_not_add_login_grep(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    spec_path = tmp_path / "tests" / "smoke" / "stripe_billing.spec.ts"
+    spec_path.parent.mkdir(parents=True)
+    spec_path.write_text("test('stripe', () => {})", encoding="utf-8")
+
+    class RuntimeState:
+        project_root = tmp_path
+        source = "tests/smoke/stripe_billing.spec.ts"
+        target = "/api/auth/login"
+
+    command = PlaywrightTemplate().generate_test_command(RuntimeState(), "smoke")
+
+    assert command == "npx playwright test tests/smoke/stripe_billing.spec.ts --reporter=line"
+
+
+def test_playwright_generate_test_command_accepts_configured_project(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runtime_state = RuntimeStateNode(
+        identifier="runtime:server:app",
+        kind=RuntimeStateKind.SERVER_RUNNING,
+        target="http://localhost:3000",
+    )
+
+    command = PlaywrightTemplate(config={"project": "desktop-1920"}).generate_test_command(runtime_state, "e2e")
+
+    assert command == "npx playwright test tests/e2e/ --reporter=line --project desktop-1920"
+
+
 def test_playwright_generate_test_command_smoke_login_has_grep(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     runtime_state = RuntimeStateNode(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -233,6 +233,9 @@ def test_generate_uses_dependency_documents_as_ai_context(tmp_path, mock_ai_cli)
     assert "--- BEGIN DEPENDENCY docs/requirements/lms_requirements_v2.0.md (req:lms-requirements-v2.0) ---" in prompt
     assert "Tenant isolation and audit logging are mandatory." in prompt
     assert "Prefer a structure that covers: Overview, Acceptance Criteria, Failure Criteria, E2E Test Generation Meta-Prompt." in prompt
+    assert "Mutating test data:" in prompt
+    assert "per-run unique identifiers" in prompt
+    assert "explicit cleanup/idempotent teardown" in prompt
 
 
 def test_generate_supports_detailed_design_documents_with_mermaid_guidance(tmp_path, mock_ai_cli):

--- a/tests/test_implement.py
+++ b/tests/test_implement.py
@@ -284,3 +284,23 @@ def test_error_summaries_excluded_from_prompt():
     assert "Successful Task" in prompt
     assert "Failed Task" not in prompt
     assert "empty implementation output" not in prompt
+
+
+def test_implementation_prompt_forbids_meta_copy_in_user_facing_ui():
+    prompt = _build_implementation_prompt(
+        config={"project": {"language": "typescript", "frameworks": ["next.js"]}},
+        design_context=DesignContext(
+            node_id="design:login",
+            path=Path("docs/design/login.md"),
+            content="# Login design\n",
+        ),
+        spec=ImplementSpec("docs/design/login.md", ["src/app/login/page.tsx"]),
+        dependency_documents=[],
+        conventions=[],
+        coding_principles=None,
+    )
+
+    assert "production user copy only" in prompt
+    assert "never surface design rationale" in prompt
+    assert "implementation assumptions" in prompt
+    assert "environment notes as visible text" in prompt


### PR DESCRIPTION
## Summary

This PR folds the LMS dogfood verification failures back into CoDD core.

- Prefer machine-executable `cdp_steps` over conceptual `steps` when building CDP runtime state and journey verification targets.
- Resolve relative CDP navigation targets against configurable `base_url` / `CODD_CDP_BASE_URL`.
- Run Playwright verification nodes against their exact `source` spec file, with optional `project` selection, instead of repeatedly invoking broad test directories.
- Suppress the legacy login grep heuristic when an exact source file is available.
- Add E2E generation guidance requiring mutating tests to use per-run unique data and cleanup/idempotent teardown.
- Add implementation prompt guidance to keep generated UI copy production-facing and prevent visible design rationale/test/demo/sample/internal environment notes.

## Root Cause

CoDD was treating human-readable user journey steps as if they were browser-executable CDP actions, and runtime verification templates were too coarse-grained. That made full `codd verify` fail or time out in a real project even when the static DAG was green.

A second dogfood failure showed that generated/maintained mutating E2E tests can become non-idempotent when they use fixed identifiers, causing repeated runs to fail on uniqueness constraints.

A third dogfood issue showed generated UI can leak design/process language such as device assumptions, sample labels, or production-state notes into end-user visible copy.

## Validation

- `.venv/bin/python -m pytest tests/test_implement.py -q` -> 9 passed
- `.venv/bin/python -m pytest tests/test_generate.py tests/test_deployment_verification_templates.py tests/deployment/test_cdp_browser_core.py tests/repair/test_verify_runner.py -q` -> 100 passed
- LMS dogfood full `codd verify` -> 29 PASS / 0 FAIL / 0 SKIP