### PR TITLE
[codex] Add presentation aggregation obligations

### DIFF
--- a/codd/cli.py
+++ b/codd/cli.py
@@ -566,6 +566,7 @@ def _doctor_warnings(project_root: Path) -> list[str]:
     warnings.extend(_interactive_control_warnings(project_root, config))
     warnings.extend(_screen_escape_route_warnings(project_root, config))
     warnings.extend(_authenticated_global_action_warnings(project_root, config))
+    warnings.extend(_presentation_obligation_warnings(project_root, config))
     coverage = _action_outcome_coverage(project_root, config)
     warnings.extend(_action_outcome_warning_messages(coverage, legacy_crud_configured=has_crud_flow_targets))
     target_actions = action_target_specs_from_config(config)
@@ -824,6 +825,223 @@ def _authenticated_global_action_warnings(project_root: Path, config: dict[str, 
         "account access, home, or primary navigation so desktop-visible session controls are not "
         f"accepted as mobile coverage.{action_note}"
     ]
+
+
+def _presentation_obligation_warnings(project_root: Path, config: dict[str, Any]) -> list[str]:
+    warnings: list[str] = []
+    for path in _configured_doc_files(project_root, config):
+        payload = _frontmatter_or_yaml_payload(path)
+        if not isinstance(payload, dict):
+            continue
+        source = _display_path(path, project_root)
+        display_fields = _presentation_entries(payload, ("display_fields", "displayed_fields", "presentation_fields"))
+        presentation_specs = _entries_by_field_id(_presentation_entries(payload, ("presentation_specs",)))
+        aggregation_policies = _entries_by_field_id(_presentation_entries(payload, ("aggregation_policies",)))
+        for field in display_fields:
+            field_id = _field_id(field)
+            if not field_id:
+                continue
+            presentation = _merge_obligation(field, presentation_specs.get(field_id), "presentation")
+            if _requires_presentation_spec(field, presentation) and not _has_any_presentation_declaration(presentation):
+                warnings.append(
+                    f"W-PRES-001: displayed field `{field_id}` in `{source}` has no presentation spec."
+                )
+            missing = _missing_i18n_presentation_attributes(field, presentation)
+            if missing:
+                warnings.append(
+                    f"W-PRES-002: locale/timezone lexicon obligation for displayed field `{field_id}` "
+                    f"in `{source}` lacks field-level {', '.join(missing)} declaration."
+                )
+
+            aggregation = _merge_obligation(field, aggregation_policies.get(field_id), "aggregation")
+            if _requires_aggregation_policy(field, aggregation) and not _has_aggregation_policy(aggregation):
+                warnings.append(
+                    f"W-AGG-001: collection/cardinality display field `{field_id}` in `{source}` "
+                    "lacks aggregation policy."
+                )
+    return warnings
+
+
+def _presentation_entries(payload: dict[str, Any], keys: tuple[str, ...]) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, list):
+            entries.extend(item for item in value if isinstance(item, dict))
+    for journey in payload.get("user_journeys", []) if isinstance(payload.get("user_journeys"), list) else []:
+        if not isinstance(journey, dict):
+            continue
+        for key in keys:
+            value = journey.get(key)
+            if isinstance(value, list):
+                entries.extend(item for item in value if isinstance(item, dict))
+    return entries
+
+
+def _entries_by_field_id(entries: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    by_field: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        field_id = _field_id(entry)
+        if field_id:
+            by_field[field_id] = entry
+    return by_field
+
+
+def _field_id(entry: dict[str, Any]) -> str:
+    for key in ("field_id", "field", "id", "name"):
+        value = entry.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _merge_obligation(field: dict[str, Any], explicit: dict[str, Any] | None, nested_key: str) -> dict[str, Any]:
+    merged: dict[str, Any] = {key: value for key, value in field.items() if not key.startswith("_")}
+    nested = field.get(nested_key)
+    if isinstance(nested, dict):
+        merged.update(nested)
+    alias = field.get(f"{nested_key}_spec")
+    if isinstance(alias, dict):
+        merged.update(alias)
+    alias = field.get(f"{nested_key}_policy")
+    if isinstance(alias, dict):
+        merged.update(alias)
+    if explicit:
+        merged.update(explicit)
+    return merged
+
+
+def _requires_presentation_spec(field: dict[str, Any], presentation: dict[str, Any]) -> bool:
+    text = _obligation_text(field, presentation)
+    return _truthy(field.get("presentation_required")) or any(
+        token in text
+        for token in (
+            "datetime",
+            "date_time",
+            "timestamp",
+            "locale",
+            "localized",
+            "timezone",
+            "time_zone",
+            "number",
+            "currency",
+            "amount",
+            "percent",
+            "i18n_unicode_cldr",
+        )
+    )
+
+
+def _missing_i18n_presentation_attributes(field: dict[str, Any], presentation: dict[str, Any]) -> list[str]:
+    text = _obligation_text(field, presentation)
+    if not any(token in text for token in ("i18n_unicode_cldr", "locale", "timezone", "time_zone")):
+        return []
+    required: list[str] = []
+    if any(token in text for token in ("time_zone", "timezone", "datetime", "date_time", "timestamp")):
+        required.extend(["format", "timezone"])
+    if any(token in text for token in ("locale", "localized", "i18n_unicode_cldr")):
+        required.append("locale")
+    return [attribute for attribute in _dedupe(required) if not _has_presentation_attribute(presentation, attribute)]
+
+
+def _has_any_presentation_declaration(presentation: dict[str, Any]) -> bool:
+    return any(
+        _has_presentation_attribute(presentation, attribute)
+        for attribute in ("format", "locale", "timezone", "unit", "precision", "calendar")
+    )
+
+
+def _has_presentation_attribute(presentation: dict[str, Any], attribute: str) -> bool:
+    aliases = {
+        "format": ("format", "pattern", "display_format", "number_format", "date_format", "time_format"),
+        "locale": ("locale", "language", "language_tag", "bcp47", "locale_tag"),
+        "timezone": ("timezone", "time_zone", "timezone_id", "iana_timezone", "iana_time_zone"),
+        "unit": ("unit", "display_unit"),
+        "precision": ("precision", "rounding", "scale"),
+        "calendar": ("calendar", "calendar_system"),
+    }
+    for key in aliases.get(attribute, (attribute,)):
+        if presentation.get(key) not in (None, "", []):
+            return True
+    return False
+
+
+def _requires_aggregation_policy(field: dict[str, Any], aggregation: dict[str, Any]) -> bool:
+    if _truthy(field.get("aggregation_required")) or _truthy(aggregation.get("required")):
+        return True
+    text = _obligation_text(field, aggregation)
+    return any(
+        token in text
+        for token in ("0..n", "1..n", "n:m", "many", "multiple", "collection", "list", "array", "repeated")
+    )
+
+
+def _has_aggregation_policy(aggregation: dict[str, Any]) -> bool:
+    if aggregation.get("policy") not in (None, "", []):
+        return True
+    if aggregation.get("aggregation_policy") not in (None, "", []):
+        return True
+    cardinality_when_many = aggregation.get("cardinality_when_many")
+    return isinstance(cardinality_when_many, dict) and cardinality_when_many.get("policy") not in (None, "", [])
+
+
+def _obligation_text(field: dict[str, Any], obligation: dict[str, Any]) -> str:
+    values: list[Any] = []
+    for source in (field, obligation):
+        for key in (
+            "field_id",
+            "field",
+            "type",
+            "kind",
+            "data_type",
+            "value_kind",
+            "lexicon_ref",
+            "lexicon_refs",
+            "axis",
+            "axis_type",
+            "cardinality",
+            "display_cardinality",
+            "collection_context",
+        ):
+            values.append(source.get(key))
+    return " ".join(_nested_strings(values)).lower()
+
+
+def _nested_strings(value: Any) -> set[str]:
+    strings: set[str] = set()
+    if value is None:
+        return strings
+    if isinstance(value, str):
+        strings.add(value)
+        return strings
+    if isinstance(value, dict):
+        for key, item in value.items():
+            strings.update(_nested_strings(key))
+            strings.update(_nested_strings(item))
+        return strings
+    if isinstance(value, (list, tuple, set)):
+        for item in value:
+            strings.update(_nested_strings(item))
+        return strings
+    strings.add(str(value))
+    return strings
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "required", "must"}
+    return bool(value)
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        if value in result:
+            continue
+        result.append(value)
+    return result
 
 
 def _looks_like_screen_file(path: Path) -> bool:

--- a/codd/dag/builder.py
+++ b/codd/dag/builder.py
@@ -809,6 +809,9 @@ def _validate_design_doc_journey_attributes(node_id: str, attributes: dict[str, 
     required_fields = {
         "runtime_constraints": ("capability", "required", "rationale"),
         "user_journeys": ("name", "criticality", "steps", "required_capabilities", "expected_outcome_refs"),
+        "display_fields": ("field_id",),
+        "presentation_specs": ("field_id",),
+        "aggregation_policies": ("field_id",),
     }
     for key, required in required_fields.items():
         entries = attributes.get(key, [])

--- a/codd/dag/checks/user_journey_coherence.py
+++ b/codd/dag/checks/user_journey_coherence.py
@@ -210,6 +210,9 @@ class UserJourneyCoherenceCheck(DagCheck):
         report["violations"].extend(
             self._browser_requirement_violations(dag, design_doc.id, journey_name, expected_nodes.values(), e2e_tests)
         )
+        report["violations"].extend(
+            self._presentation_obligation_violations(dag, design_doc, journey_name, journey, e2e_tests)
+        )
         if not self._has_assertion_step(journey):
             report["violations"].append(
                 self._violation(
@@ -340,6 +343,329 @@ class UserJourneyCoherenceCheck(DagCheck):
                     )
                 )
         return violations
+
+    def _presentation_obligation_violations(
+        self,
+        dag: DAG,
+        design_doc: Node,
+        journey_name: str,
+        journey: dict[str, Any],
+        e2e_tests: list[Node],
+    ) -> list[dict[str, Any]]:
+        del dag
+        display_fields = self._display_field_entries(design_doc, journey)
+        if not display_fields:
+            return []
+
+        presentation_specs = self._entries_by_field_id(
+            self._structured_entries(design_doc.attributes, "presentation_specs")
+            + self._structured_entries(journey, "presentation_specs")
+        )
+        aggregation_policies = self._entries_by_field_id(
+            self._structured_entries(design_doc.attributes, "aggregation_policies")
+            + self._structured_entries(journey, "aggregation_policies")
+        )
+
+        violations: list[dict[str, Any]] = []
+        for index, field in enumerate(display_fields):
+            field_id = self._field_id(field)
+            if not field_id:
+                continue
+            required_by = self._display_field_required_by(field, index)
+            presentation = self._merged_obligation(field, presentation_specs.get(field_id), "presentation")
+            missing_presentation = self._missing_presentation_attributes(field, presentation)
+            if missing_presentation:
+                violations.append(
+                    self._violation(
+                        "presentation_locale_unspecified",
+                        journey_name,
+                        design_doc.id,
+                        field_id=field_id,
+                        required_by=required_by,
+                        missing_attributes=missing_presentation,
+                        lexicon_refs=self._lexicon_refs_from_obligation(field, presentation),
+                    )
+                )
+            else:
+                missing_signals = self._missing_asserted_signals(
+                    e2e_tests,
+                    self._expected_presentation_signals(field, presentation),
+                )
+                if missing_signals:
+                    violations.append(
+                        self._violation(
+                            "presentation_locale_violated",
+                            journey_name,
+                            design_doc.id,
+                            field_id=field_id,
+                            required_by=required_by,
+                            missing_evidence_signals=missing_signals,
+                        )
+                    )
+
+            aggregation = self._merged_obligation(field, aggregation_policies.get(field_id), "aggregation")
+            if self._requires_aggregation_policy(field, aggregation) and not self._has_aggregation_policy(aggregation):
+                violations.append(
+                    self._violation(
+                        "aggregation_policy_unspecified",
+                        journey_name,
+                        design_doc.id,
+                        field_id=field_id,
+                        required_by=required_by,
+                        cardinality=self._first_present(field, aggregation, keys=("cardinality", "display_cardinality")),
+                    )
+                )
+                continue
+
+            missing_aggregation_signals = self._missing_asserted_signals(
+                e2e_tests,
+                self._expected_aggregation_signals(field, aggregation),
+            )
+            if missing_aggregation_signals:
+                violations.append(
+                    self._violation(
+                        "aggregation_policy_violated",
+                        journey_name,
+                        design_doc.id,
+                        field_id=field_id,
+                        required_by=required_by,
+                        missing_evidence_signals=missing_aggregation_signals,
+                    )
+                )
+        return violations
+
+    def _display_field_entries(self, design_doc: Node, journey: dict[str, Any]) -> list[dict[str, Any]]:
+        entries: list[dict[str, Any]] = []
+        for source_name, source in (("design_doc", design_doc.attributes), ("journey", journey)):
+            for key in ("display_fields", "displayed_fields", "presentation_fields"):
+                for index, entry in enumerate(self._structured_entries(source, key)):
+                    annotated = dict(entry)
+                    annotated.setdefault("_source", source_name)
+                    annotated.setdefault("_source_key", key)
+                    annotated.setdefault("_source_index", index)
+                    entries.append(annotated)
+        return entries
+
+    def _structured_entries(self, mapping: dict[str, Any], key: str) -> list[dict[str, Any]]:
+        entries = mapping.get(key, [])
+        return [entry for entry in entries if isinstance(entry, dict)] if isinstance(entries, list) else []
+
+    def _entries_by_field_id(self, entries: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        by_field: dict[str, dict[str, Any]] = {}
+        for entry in entries:
+            field_id = self._field_id(entry)
+            if field_id:
+                by_field[field_id] = entry
+        return by_field
+
+    def _field_id(self, entry: dict[str, Any]) -> str:
+        for key in ("field_id", "field", "id", "name"):
+            value = entry.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
+
+    def _display_field_required_by(self, field: dict[str, Any], fallback_index: int) -> str:
+        source = str(field.get("_source") or "design_doc")
+        key = str(field.get("_source_key") or "display_fields")
+        index = field.get("_source_index")
+        if not isinstance(index, int):
+            index = fallback_index
+        if source == "journey":
+            return f"design_doc.user_journeys[].{key}[{index}]"
+        return f"design_doc.{key}[{index}]"
+
+    def _merged_obligation(
+        self,
+        field: dict[str, Any],
+        explicit: dict[str, Any] | None,
+        nested_key: str,
+    ) -> dict[str, Any]:
+        merged: dict[str, Any] = {key: value for key, value in field.items() if not key.startswith("_")}
+        nested = field.get(nested_key)
+        if isinstance(nested, dict):
+            merged.update(nested)
+        alias = field.get(f"{nested_key}_spec")
+        if isinstance(alias, dict):
+            merged.update(alias)
+        alias = field.get(f"{nested_key}_policy")
+        if isinstance(alias, dict):
+            merged.update(alias)
+        if explicit:
+            merged.update(explicit)
+        return merged
+
+    def _missing_presentation_attributes(self, field: dict[str, Any], presentation: dict[str, Any]) -> list[str]:
+        required = self._required_presentation_attributes(field, presentation)
+        if not required:
+            return []
+        if not self._has_any_presentation_declaration(presentation):
+            return ["presentation_spec"]
+        missing = [attribute for attribute in required if not self._has_presentation_attribute(presentation, attribute)]
+        return self._dedupe_strings(missing)
+
+    def _required_presentation_attributes(
+        self,
+        field: dict[str, Any],
+        presentation: dict[str, Any],
+    ) -> list[str]:
+        text = self._obligation_text(field, presentation)
+        required: list[str] = []
+        if self._truthy(field.get("presentation_required")) or self._truthy(presentation.get("required")):
+            required.append("format")
+        if any(token in text for token in ("datetime", "date_time", "timestamp", "time_zone", "timezone")):
+            required.extend(["format", "timezone"])
+        if any(token in text for token in ("locale", "localized", "i18n_unicode_cldr", "date_time_calendar")):
+            required.append("locale")
+        if any(token in text for token in ("number", "currency", "amount", "percentage", "percent")):
+            required.append("format")
+        return self._dedupe_strings(required)
+
+    def _has_any_presentation_declaration(self, presentation: dict[str, Any]) -> bool:
+        return any(
+            self._has_presentation_attribute(presentation, attribute)
+            for attribute in ("format", "locale", "timezone", "unit", "precision", "calendar")
+        )
+
+    def _has_presentation_attribute(self, presentation: dict[str, Any], attribute: str) -> bool:
+        aliases = {
+            "format": ("format", "pattern", "display_format", "number_format", "date_format", "time_format"),
+            "locale": ("locale", "language", "language_tag", "bcp47", "locale_tag"),
+            "timezone": ("timezone", "time_zone", "timezone_id", "iana_timezone", "iana_time_zone"),
+            "unit": ("unit", "display_unit"),
+            "precision": ("precision", "rounding", "scale"),
+            "calendar": ("calendar", "calendar_system"),
+        }
+        for key in aliases.get(attribute, (attribute,)):
+            value = presentation.get(key)
+            if value not in (None, "", []):
+                return True
+        return False
+
+    def _expected_presentation_signals(
+        self,
+        field: dict[str, Any],
+        presentation: dict[str, Any],
+    ) -> list[str]:
+        return self._expected_obligation_signals(
+            field,
+            presentation,
+            keys=(
+                "expected_presentation_signals",
+                "presentation_expected_signals",
+                "presentation_assertions",
+                "evidence_signals",
+            ),
+        )
+
+    def _requires_aggregation_policy(self, field: dict[str, Any], aggregation: dict[str, Any]) -> bool:
+        if self._truthy(field.get("aggregation_required")) or self._truthy(aggregation.get("required")):
+            return True
+        text = self._obligation_text(field, aggregation)
+        return any(
+            token in text
+            for token in (
+                "0..n",
+                "1..n",
+                "n:m",
+                "many",
+                "multiple",
+                "collection",
+                "list",
+                "array",
+                "repeated",
+            )
+        )
+
+    def _has_aggregation_policy(self, aggregation: dict[str, Any]) -> bool:
+        if aggregation.get("policy") not in (None, "", []):
+            return True
+        if aggregation.get("aggregation_policy") not in (None, "", []):
+            return True
+        cardinality_when_many = aggregation.get("cardinality_when_many")
+        return isinstance(cardinality_when_many, dict) and cardinality_when_many.get("policy") not in (None, "", [])
+
+    def _expected_aggregation_signals(
+        self,
+        field: dict[str, Any],
+        aggregation: dict[str, Any],
+    ) -> list[str]:
+        return self._expected_obligation_signals(
+            field,
+            aggregation,
+            keys=(
+                "expected_aggregation_signals",
+                "aggregation_expected_signals",
+                "aggregation_assertions",
+                "evidence_signals",
+            ),
+        )
+
+    def _expected_obligation_signals(
+        self,
+        field: dict[str, Any],
+        obligation: dict[str, Any],
+        *,
+        keys: tuple[str, ...],
+    ) -> list[str]:
+        signals: list[str] = []
+        for source in (field, obligation):
+            for key in keys:
+                signals.extend(str(item) for item in self._as_list(source.get(key)) if item)
+        return self._dedupe_strings(signals)
+
+    def _missing_asserted_signals(self, tests: list[Node], signals: list[str]) -> list[str]:
+        if not tests or not signals:
+            return []
+        return [signal for signal in signals if not self._any_test_asserts(tests, signal)]
+
+    def _lexicon_refs_from_obligation(self, field: dict[str, Any], obligation: dict[str, Any]) -> list[str]:
+        refs: list[str] = []
+        for source in (field, obligation):
+            for key in ("lexicon_ref", "lexicon_refs", "lexicon"):
+                refs.extend(str(item) for item in self._as_list(source.get(key)) if item)
+        return self._dedupe_strings(refs)
+
+    def _obligation_text(self, field: dict[str, Any], obligation: dict[str, Any]) -> str:
+        values: list[Any] = []
+        for source in (field, obligation):
+            for key in (
+                "field_id",
+                "field",
+                "type",
+                "kind",
+                "data_type",
+                "value_kind",
+                "lexicon_ref",
+                "lexicon_refs",
+                "axis",
+                "axis_type",
+                "cardinality",
+                "display_cardinality",
+                "collection_context",
+            ):
+                values.append(source.get(key))
+        return " ".join(self._nested_strings(values)).lower()
+
+    def _first_present(
+        self,
+        *mappings: dict[str, Any],
+        keys: tuple[str, ...],
+    ) -> Any:
+        for mapping in mappings:
+            for key in keys:
+                value = mapping.get(key)
+                if value not in (None, "", []):
+                    return value
+        return None
+
+    @staticmethod
+    def _truthy(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "required", "must"}
+        return bool(value)
 
     def _plan_tasks_for_journey(self, dag: DAG, journey_name: str, lex_refs: list[str]) -> list[Node]:
         matches: list[Node] = []

--- a/codd/dag/extractor.py
+++ b/codd/dag/extractor.py
@@ -29,6 +29,12 @@ _IMPORT_SPECIFIER_RE = re.compile(
 RUNTIME_CONSTRAINT_REQUIRED_FIELDS = ("capability", "required", "rationale")
 USER_JOURNEY_REQUIRED_FIELDS = ("name", "criticality", "steps", "required_capabilities", "expected_outcome_refs")
 USER_JOURNEY_LIST_FIELDS = ("steps", "required_capabilities", "expected_outcome_refs")
+DISPLAY_FIELD_REQUIRED_FIELDS = ("field_id",)
+DISPLAY_FIELD_LIST_FIELDS = ("lexicon_refs", "evidence_signals")
+PRESENTATION_SPEC_REQUIRED_FIELDS = ("field_id",)
+PRESENTATION_SPEC_LIST_FIELDS = ("lexicon_refs", "evidence_signals", "expected_presentation_signals")
+AGGREGATION_POLICY_REQUIRED_FIELDS = ("field_id",)
+AGGREGATION_POLICY_LIST_FIELDS = ("evidence_signals", "expected_aggregation_signals", "allowed_policies")
 DESIGN_DOC_ATTRIBUTE_SCHEMAS = {
     "runtime_constraints": {
         "required_fields": RUNTIME_CONSTRAINT_REQUIRED_FIELDS,
@@ -41,6 +47,18 @@ DESIGN_DOC_ATTRIBUTE_SCHEMAS = {
     "coverage_axes": {
         "required_fields": (),
         "list_fields": (),
+    },
+    "display_fields": {
+        "required_fields": DISPLAY_FIELD_REQUIRED_FIELDS,
+        "list_fields": DISPLAY_FIELD_LIST_FIELDS,
+    },
+    "presentation_specs": {
+        "required_fields": PRESENTATION_SPEC_REQUIRED_FIELDS,
+        "list_fields": PRESENTATION_SPEC_LIST_FIELDS,
+    },
+    "aggregation_policies": {
+        "required_fields": AGGREGATION_POLICY_REQUIRED_FIELDS,
+        "list_fields": AGGREGATION_POLICY_LIST_FIELDS,
     },
 }
 DESIGN_DOC_ATTRIBUTE_KEYS = tuple(DESIGN_DOC_ATTRIBUTE_SCHEMAS)

--- a/codd_plugins/lexicons/data_aggregation_policies/coverage_matrix.md
+++ b/codd_plugins/lexicons/data_aggregation_policies/coverage_matrix.md
@@ -1,0 +1,11 @@
+# Data Aggregation Policies Coverage Matrix
+
+| Axis | Covered | Implicit | Gap |
+|------|---------|----------|-----|
+| `collection_cardinality` | Zero, one, and many source-record cases are stated. | Cardinality is inferable from a schema or API shape. | A displayed value can collapse many records without stated behavior. |
+| `test_data_variation` | Seed, fixture, or generated data covers zero, one, and many-record variants. | The data generator implies variants but does not name them. | Tests can run without data that exercises the declared cardinality cases. |
+| `aggregation_function` | The summary, selection, grouping, or expansion policy is declared. | A named artifact implies the policy. | The display gives one value but does not state how it was derived. |
+| `empty_partial_state` | Empty and partial placeholders or fallbacks are declared. | Empty behavior is inherited from a shared UI convention. | Missing source data can look like a valid value. |
+| `grouping_dimension` | Group key, order, and labels are declared. | Grouping is inherited from a referenced component contract. | Grouped output lacks a declared dimension or order. |
+| `recency_selection` | Timestamp source, window, and tie-breaker are declared. | Recency behavior is implied by a named query. | Latest or windowed display lacks source or tie-break policy. |
+| `source_traceability` | Source count, drilldown, or calculation label is declared. | Traceability exists in linked diagnostics only. | A summary cannot be explained or verified from declared behavior. |

--- a/codd_plugins/lexicons/data_aggregation_policies/elicit_extend.md
+++ b/codd_plugins/lexicons/data_aggregation_policies/elicit_extend.md
@@ -1,0 +1,31 @@
+---
+extends: codd/elicit/templates/elicit_prompt_L0.md
+---
+
+# Data Aggregation Policy Coverage Lexicon
+
+Use this lexicon when a requirement describes a displayed value derived from a collection, a summary, a group, or a recency-based selection.
+
+Classify each axis as:
+
+- `covered`: the requirement states the field, cardinality case, policy, and expected visible behavior.
+- `implicit`: the policy can be inferred from a referenced artifact, but the requirement does not state it directly.
+- `gap`: a displayed value can represent many source records and the policy is missing or ambiguous.
+
+Coverage axes:
+
+- `collection_cardinality`
+- `test_data_variation`
+- `aggregation_function`
+- `empty_partial_state`
+- `grouping_dimension`
+- `recency_selection`
+- `source_traceability`
+
+Prefer concrete requirement questions such as:
+
+- Which field is displayed, and can it represent zero, one, or many source records?
+- Which seed, fixture, or generated data proves the zero, one, and many-record variants?
+- If many source records exist, is the value summarized, selected, grouped, or expanded?
+- What should users see when no source record or only partial source data exists?
+- What test variants prove zero, one, and many source-record behavior?

--- a/codd_plugins/lexicons/data_aggregation_policies/lexicon.yaml
+++ b/codd_plugins/lexicons/data_aggregation_policies/lexicon.yaml
@@ -1,0 +1,117 @@
+coverage_axes:
+  - axis_type: "collection_cardinality"
+    rationale: "A displayed value can represent zero, one, or many source records, and the expected behavior changes for each case."
+    criticality_default: high
+    variants:
+      - id: "zero"
+        label: "Zero source records"
+        attributes: {source_literal: "0", coverage_target: "empty display behavior"}
+        criticality: medium
+      - id: "one"
+        label: "One source record"
+        attributes: {source_literal: "1", coverage_target: "direct display behavior"}
+        criticality: medium
+      - id: "many"
+        label: "Many source records"
+        attributes: {source_literal: "N", coverage_target: "aggregation or expansion behavior"}
+        criticality: high
+  - axis_type: "test_data_variation"
+    rationale: "A declared cardinality policy is not executable unless seed, fixture, or generated data covers the zero, one, and many-record variants."
+    criticality_default: high
+    variants:
+      - id: "seed_zero_records"
+        label: "Seed covers zero records"
+        attributes: {source_literal: "seed 0", coverage_target: "empty test data variant"}
+        criticality: medium
+      - id: "seed_one_record"
+        label: "Seed covers one record"
+        attributes: {source_literal: "seed 1", coverage_target: "single-record test data variant"}
+        criticality: medium
+      - id: "seed_many_records"
+        label: "Seed covers many records"
+        attributes: {source_literal: "seed N", coverage_target: "many-record test data variant"}
+        criticality: high
+  - axis_type: "aggregation_function"
+    rationale: "When many records map to one display slot, the policy must state whether the value is summarized, selected, grouped, or expanded."
+    criticality_default: high
+    variants:
+      - id: "average"
+        label: "Average or mean"
+        attributes: {source_literal: "average", coverage_target: "numeric summary policy"}
+        criticality: high
+      - id: "maximum"
+        label: "Maximum value"
+        attributes: {source_literal: "max", coverage_target: "extreme-value selection policy"}
+        criticality: medium
+      - id: "latest"
+        label: "Latest value"
+        attributes: {source_literal: "latest", coverage_target: "recency-based selection policy"}
+        criticality: high
+      - id: "expanded_list"
+        label: "Expanded list"
+        attributes: {source_literal: "list", coverage_target: "show each member instead of collapsing"}
+        criticality: high
+  - axis_type: "empty_partial_state"
+    rationale: "Empty and partial data states need explicit placeholder, fallback, and confidence behavior so display meaning stays unambiguous."
+    criticality_default: medium
+    variants:
+      - id: "empty_placeholder"
+        label: "Empty placeholder"
+        attributes: {source_literal: "empty", coverage_target: "zero-record display"}
+        criticality: medium
+      - id: "partial_indicator"
+        label: "Partial indicator"
+        attributes: {source_literal: "partial", coverage_target: "incomplete-source display"}
+        criticality: medium
+      - id: "unknown_marker"
+        label: "Unknown marker"
+        attributes: {source_literal: "unknown", coverage_target: "unavailable-value display"}
+        criticality: medium
+  - axis_type: "grouping_dimension"
+    rationale: "Grouped displays need the dimension, ordering, and label policy declared so readers can tell what each group means."
+    criticality_default: medium
+    variants:
+      - id: "group_by_category"
+        label: "Group by category"
+        attributes: {source_literal: "group by", coverage_target: "category grouping"}
+        criticality: medium
+      - id: "group_sort_order"
+        label: "Group sort order"
+        attributes: {source_literal: "sort", coverage_target: "group ordering"}
+        criticality: medium
+      - id: "group_label"
+        label: "Group label"
+        attributes: {source_literal: "label", coverage_target: "group label semantics"}
+        criticality: medium
+  - axis_type: "recency_selection"
+    rationale: "Latest or time-windowed displays need the timestamp source, tie-breaking, and window boundary policy declared."
+    criticality_default: high
+    variants:
+      - id: "timestamp_source"
+        label: "Timestamp source"
+        attributes: {source_literal: "timestamp", coverage_target: "recency input"}
+        criticality: high
+      - id: "tie_breaker"
+        label: "Tie breaker"
+        attributes: {source_literal: "tie", coverage_target: "same-time selection behavior"}
+        criticality: medium
+      - id: "window_boundary"
+        label: "Window boundary"
+        attributes: {source_literal: "window", coverage_target: "time-window inclusion behavior"}
+        criticality: medium
+  - axis_type: "source_traceability"
+    rationale: "A summarized value should expose or document enough source context for users and tests to verify what records contributed to it."
+    criticality_default: medium
+    variants:
+      - id: "source_count"
+        label: "Source count"
+        attributes: {source_literal: "count", coverage_target: "number of contributing records"}
+        criticality: medium
+      - id: "source_link"
+        label: "Source drilldown link"
+        attributes: {source_literal: "source", coverage_target: "inspect contributing records"}
+        criticality: medium
+      - id: "calculation_label"
+        label: "Calculation label"
+        attributes: {source_literal: "calculation", coverage_target: "visible or documented summary method"}
+        criticality: medium

--- a/codd_plugins/lexicons/data_aggregation_policies/manifest.yaml
+++ b/codd_plugins/lexicons/data_aggregation_policies/manifest.yaml
@@ -1,0 +1,20 @@
+id: data_aggregation_policies
+name: "Data Aggregation Policies"
+lexicon_name: data_aggregation_policies
+version: "1.0.0"
+standard: "CoDD data presentation policy"
+domain: cross_industry
+source_url: "https://github.com/yohey-w/codd-dev"
+source_version: "CoDD generic presentation policy"
+description: "Coverage axes for declaring how one display slot represents zero, one, or many source records."
+observation_dimensions: 7
+extends: "codd/elicit/templates/elicit_prompt_L0.md"
+prompt_extension: "elicit_extend.md"
+recommended_kinds: "recommended_kinds.yaml"
+lexicon: "lexicon.yaml"
+severity_rules: "severity_rules.yaml"
+coverage_matrix: "coverage_matrix.md"
+references:
+  - title: "CoDD User Journey Coherence Layer"
+    url: "docs/design/user-journey-coherence.md"
+    source_version: "presentation-aggregation-obligations"

--- a/codd_plugins/lexicons/data_aggregation_policies/recommended_kinds.yaml
+++ b/codd_plugins/lexicons/data_aggregation_policies/recommended_kinds.yaml
@@ -1,0 +1,8 @@
+recommended_kinds:
+  - cardinality_display_gap
+  - test_data_variation_gap
+  - aggregation_policy_gap
+  - empty_partial_state_gap
+  - grouping_dimension_gap
+  - recency_selection_gap
+  - source_traceability_gap

--- a/codd_plugins/lexicons/data_aggregation_policies/severity_rules.yaml
+++ b/codd_plugins/lexicons/data_aggregation_policies/severity_rules.yaml
@@ -1,0 +1,25 @@
+rules:
+  - when: "axis=collection_cardinality AND coverage=gap"
+    severity: high
+    rationale: "Missing cardinality expectations can make a one-value display ambiguous when many records exist."
+  - when: "axis=test_data_variation AND coverage=gap"
+    severity: high
+    rationale: "Missing zero, one, or many-record test data can leave declared aggregation behavior unexercised."
+  - when: "axis=aggregation_function AND coverage=gap"
+    severity: high
+    rationale: "Missing aggregation policy can hide whether a displayed value is selected, summarized, grouped, or expanded."
+  - when: "axis=empty_partial_state AND coverage=gap"
+    severity: medium
+    rationale: "Missing empty or partial behavior can make absent data look like a valid value."
+  - when: "axis=grouping_dimension AND coverage=gap"
+    severity: medium
+    rationale: "Missing grouping policy can make grouped output hard to interpret or test."
+  - when: "axis=recency_selection AND coverage=gap"
+    severity: high
+    rationale: "Missing recency policy can select the wrong source record or make time-window behavior ambiguous."
+  - when: "axis=source_traceability AND coverage=gap"
+    severity: medium
+    rationale: "Missing source traceability can make summaries difficult to explain or verify."
+  - when: "coverage=implicit"
+    severity: info
+    rationale: "Implicit aggregation coverage should be reviewed but is not a blocking gap by default."

--- a/codd_plugins/stack_map.yaml
+++ b/codd_plugins/stack_map.yaml
@@ -6,6 +6,7 @@ stack_map:
       - web_performance_core_web_vitals
       - web_browser_compat
       - web_forms_html5
+      - data_aggregation_policies
       - web_pwa_manifest
       - web_seo_schemaorg
   - hint_pattern: "fastapi|flask|django|express|hono|nestjs|spring|rails|sinatra|laravel"

--- a/docs/cookbook/presentation_aggregation/README.md
+++ b/docs/cookbook/presentation_aggregation/README.md
@@ -1,0 +1,37 @@
+# Presentation And Aggregation Obligations
+
+Use this pattern when a user journey displays fields whose meaning depends on locale, timezone, number formatting, or a many-to-one data policy.
+
+```yaml
+user_journeys:
+  - name: review_record_overview
+    criticality: high
+    steps:
+      - { action: navigate, target: /records }
+      - { action: expect_visible, value: record_summary_many_source_display }
+    expected_outcome_refs: [lexicon:record_overview_display]
+    display_fields:
+      - field_id: "record.published_at"
+        data_type: "datetime"
+        lexicon_refs: ["i18n_unicode_cldr#time_zone_handling"]
+        presentation_required: true
+        presentation:
+          format: "YYYY-MM-DD HH:mm"
+          timezone: "Etc/UTC"
+          locale: "en-US"
+        expected_presentation_signals: ["record_published_at_locale_display"]
+      - field_id: "record.summary_value"
+        cardinality: "0..N"
+        aggregation_required: true
+        aggregation:
+          cardinality_when_zero: { display: "empty_state" }
+          cardinality_when_one: { display: "raw" }
+          cardinality_when_many:
+            policy: "average"
+            source_traceability: "source_count"
+          test_data_variants:
+            required_cardinality: ["0", "1", "N"]
+        expected_aggregation_signals: ["record_summary_many_source_display"]
+```
+
+The important contract is that each displayed field has three matching parts: the obligation, an assertion signal, and test data that exercises the required variant set.

--- a/docs/design/coverage-obligation-driven-e2e-v0.md
+++ b/docs/design/coverage-obligation-driven-e2e-v0.md
@@ -1,0 +1,526 @@
+---
+codd:
+  node_id: "design:coverage-obligation-driven-e2e-v0"
+  type: design
+  status: proposed
+  depends_on:
+    - id: "design:user-journey-coherence"
+      relation: extends
+    - id: "design:verify-architecture"
+      relation: aligns_with
+    - id: "design:cdp-browser-e2e"
+      relation: aligns_with
+    - id: "requirements:codd-requirements-v2"
+      relation: implements
+---
+
+# Coverage-Obligation Driven E2E v0
+
+Status: proposed design.
+
+## Summary
+
+Coverage-Obligation Driven E2E is the top-level concept. CoDD should not generate E2E
+tests from routes, buttons, or isolated Persona-Journey examples alone. It should first
+derive explicit `coverage_obligation` records from requirements, design docs, lexicon,
+runtime constraints, static extraction, and existing verification declarations. Then it
+should generate E2E candidates, select a minimal risk-aware suite, and emit a trace matrix
+that shows every obligation as covered, delegated, waived, or uncovered.
+
+Persona-Journey is therefore not a standalone first-class product concept. It is a subset:
+`kind: role_sequence`, meaning "role x sequence obligation". An administrator,
+organization operator, or end-user journey is valuable because it covers a
+sequence of obligations under an actor, not because "journey" is separate from coverage.
+
+## Non-Goals
+
+- Do not add new DAG node kinds by default. Prefer existing `design_doc`, `expected`,
+  `verification_test`, `plan_task`, and runtime report attributes unless implementation
+  analysis later proves that a new kind is unavoidable.
+- Do not weaken existing `global-action`, `action-outcome`, `crud-flow`, `connectivity`,
+  `breakpoint-coverage`, or `e2e` checks. This design should coordinate them.
+
+## External Research
+
+| Area | Source | What CoDD adopts | Why |
+| --- | --- | --- | --- |
+| Model-Based Testing | ISTQB CT-MBT overview: https://istqb.org/certifications/certified-tester-model-based-tester-ct-mbt/ | Generate candidates from behavioral models: actors, states, actions, transitions, and selection criteria. | CoDD already has screen-flow extraction, user journey declarations, and verification templates. MBT gives the right abstraction for turning those into candidate paths instead of ad hoc test stubs. |
+| Risk-Based Testing | ISTQB glossary: https://istqb-glossary.page/risk-based-testing/ | Assign `risk_level` and use it to prioritize selection depth, waiver strictness, and required evidence. | CoDD cannot run exhaustive E2E. Risk levels let high-impact obligations demand E2E while low-risk obligations can delegate to lower-level tests or require explicit waiver. |
+| Combinatorial / t-way Testing | NIST ACTS FAQ: https://csrc.nist.gov/projects/automated-combinatorial-testing-for-software/faqs | Use t-way combinations for parameter axes such as role, breakpoint, auth state, data cardinality, locale/timezone, and runtime target. | NIST's interaction-rule framing supports covering important combinations without exhaustive enumeration. This maps directly to CoDD's role and breakpoint coverage problem. |
+| Example Mapping / BDD | Cucumber Example Mapping: https://cucumber.io/docs/bdd/example-mapping/ and BDD overview: https://cucumber.io/docs/bdd/ | Capture story/rule/example/question shape as source material for obligations; unanswered questions become uncovered or blocked obligations, not silent gaps. | CoDD needs concrete examples, but the important artifact is the rule-to-example mapping. This prevents a single happy-path scenario from masquerading as full behavior coverage. |
+| Playwright E2E practice | Playwright best practices: https://playwright.dev/docs/best-practices | Generated E2E should assert user-visible behavior, use resilient user-facing locators, isolate data/session state, run on CI, and fail on skipped coverage. | CoDD's selected E2E suite must be stable enough to serve as a gate. This source also supports sharding/parallelism and web-first assertions for reliable execution. |
+
+Adoption boundary: external methods are adopted as design inputs, not as wholesale
+framework dependencies. CoDD should express them in its own coverage vocabulary.
+
+## Existing CoDD Alignment
+
+| Existing concept | Current role | Coverage-obligation role |
+| --- | --- | --- |
+| `user_journeys` / C7 `user_journey_coherence` | Declares and checks browser-level user journeys through existing `design_doc` attributes. | Elevated into `kind: role_sequence` obligations. Missing role journeys become uncovered obligations unless explicitly waived. |
+| `global-action` | Runtime category for global/session actions such as authenticated logout across breakpoints. | Becomes `kind: global_action` obligations, often cross-product with role and breakpoint axes. |
+| `action-outcome` | Verifies a visible command reaches its intended outcome. | Becomes `kind: action_outcome` obligations with trigger, expected outcomes, side effects, and evidence. |
+| `crud-flow` | Verifies mutation reflected in UI/API. | Becomes `kind: crud_flow` obligations. Some can delegate to API/component tests when browser behavior is not the risk. |
+| `connectivity` | Verifies dev server, DB, and target availability. | Remains a runtime prerequisite obligation; failure blocks E2E evidence, not coverage completeness by itself. |
+| `breakpoint-coverage` | Captures responsive layout obligations, especially mobile/desktop substitutions. | Becomes an axis for role-sequence and global-action obligations, with t-way strength by risk. |
+| `e2e` | Existing runtime category / verification artifact. | Becomes one possible evidence type in `covered_by`; not the only valid coverage status. |
+| `display_fields`, `presentation_specs`, `aggregation_policies` | C7-related declarative obligations for field display and aggregation. | Elevated into `kind: presentation_locale` and `kind: aggregation_policy` obligations. |
+| `e2e_extractor.py` / `e2e_generator.py` | Extracts scenarios and renders framework-specific stubs. | Should feed `generated_e2e_candidates` after obligations exist, rather than being the source of truth. |
+| `coverage_auditor.py` | Classifies coverage gaps as AUTO_ACCEPT / ASK / AUTO_REJECT. | Remains a decision aid, but the authoritative status is `coverage_status` on obligations. |
+| `coverage_metrics.py` | Computes coverage ratios for design/test/CI/DAG completeness. | Can aggregate obligation statuses into trace and readiness metrics. |
+
+## Naming
+
+Recommended public term: Coverage-Obligation Driven E2E.
+
+Recommended internal object: `coverage_obligation`.
+
+Do not use "Persona-Journey coverage" as the top-level feature name. Use "Persona-Journey"
+only when talking about the role-sequence subset.
+
+## Concept Model
+
+An obligation is an atomic behavior, constraint, evidence requirement, or sequence that
+CoDD must account for. It may be covered by E2E, covered by a lower-level test, waived
+with a reason and expiry, or uncovered.
+
+Recommended obligation kinds:
+
+| Kind | Meaning | Typical source |
+| --- | --- | --- |
+| `role_sequence` | Actor follows a meaningful 5-10 step workflow. | `design_doc.user_journeys`, stakeholder roles, requirements, screen-flow. |
+| `action_outcome` | Visible command produces the promised outcome. | `operation_flow`, visible controls, action-outcome targets. |
+| `global_action` | Global/session action exists and works across relevant contexts. | `runtime.global_action_targets`, auth requirements. |
+| `breakpoint_coverage` | Behavior remains available on responsive breakpoints. | UI/layout requirements, breakpoint runtime targets. |
+| `crud_flow` | Create/read/update/delete flow mutates and reflects state. | runtime CRUD targets, requirements. |
+| `connectivity` | Runtime prerequisite is reachable and coherent. | runtime smoke categories. |
+| `presentation_locale` | User-visible value uses the required format/locale/timezone. | `display_fields`, `presentation_specs`. |
+| `aggregation_policy` | Multi-record display declares and proves aggregation semantics. | `aggregation_policies`. |
+| `runtime_capability` | Deployment/runtime provides required capability. | `runtime_constraints`, `runtime_state`. |
+| `lower_level_contract` | API/unit/component test intentionally owns the evidence. | tests, trace declarations. |
+
+## Schema Proposal
+
+Minimum schema:
+
+```yaml
+coverage_obligation:
+  obligation_id: "obl:role_sequence:platform_admin:account_lifecycle"
+  source:
+    type: "design_doc | requirement | lexicon | runtime | static | manual"
+    ref: "docs/design/example.md#user_journeys[platform_admin_account_lifecycle]"
+  kind: "role_sequence"
+  actor: "platform_admin"
+  goal: "Create and manage an account lifecycle from the admin console."
+  preconditions:
+    - "platform_admin is authenticated"
+    - "target account name is unique"
+  expected_outcomes:
+    - "account appears in the account list"
+    - "account detail reflects saved values"
+  side_effects:
+    - "account record is created"
+    - "audit event is emitted"
+  risk_level: "P0 | P1 | P2 | P3"
+  coverage_status: "covered_by_e2e | covered_by_lower_test | waived_with_reason_and_expiry | uncovered"
+  covered_by:
+    - type: "verification_test"
+      ref: "tests/smoke/admin-account-lifecycle.spec.ts"
+  waiver_reason: null
+  waiver_expiry: null
+```
+
+Optional but recommended fields:
+
+```yaml
+  sequence_steps:
+    - "open admin dashboard"
+    - "open accounts"
+    - "create account"
+    - "confirm list/detail"
+  risk_drivers:
+    - "money_or_contract_impact"
+    - "cross_role_access"
+  pairwise_parameters:
+    role: ["platform_admin"]
+    breakpoint: ["desktop", "mobile"]
+    locale: ["ja-JP"]
+    data_cardinality: ["zero", "one", "many"]
+  evidence_signals:
+    - "account_created_visible"
+    - "audit_event_visible"
+  tags:
+    - "example:generic-admin"
+  last_verified_at: null
+```
+
+Required field semantics:
+
+- `obligation_id`: stable, unique, deterministic where possible.
+- `source`: the earliest authoritative source and path/anchor that caused the obligation.
+- `kind`: normalized vocabulary, not project-specific wording.
+- `actor`: normalized role or `system` when no human actor exists.
+- `goal`: concise user/business/runtime intent.
+- `preconditions`: explicit setup needed for a valid test.
+- `expected_outcomes`: user-visible or externally observable outcomes.
+- `side_effects`: persisted, emitted, logged, or cross-service effects.
+- `risk_level`: drives depth and candidate selection. Use project policy, but default to P0-P3.
+- `coverage_status`: one of the four normalized values below.
+- `covered_by`: evidence references when status is covered.
+- `waiver_reason`: required only for waiver status.
+- `waiver_expiry`: required only for waiver status.
+
+## Coverage Status Semantics
+
+Allowed statuses:
+
+- `covered_by_e2e`: at least one E2E test or runtime verification covers the obligation.
+- `covered_by_lower_test`: the obligation is intentionally delegated to unit/API/component/static
+  tests and does not need E2E for current risk.
+- `waived_with_reason_and_expiry`: a human-readable reason and future expiry date are present.
+- `uncovered`: no valid coverage, delegation, or current waiver exists.
+
+Incomplete states:
+
+- `SKIP` is incomplete. A skipped E2E cannot produce `covered_by_e2e`.
+- Implicit opt-out is incomplete. Absence of a journey, target, or status is not a waiver.
+- Expired waiver is incomplete. It must revert to `uncovered`.
+- "No user_journeys declared" is incomplete when roles, screens, actions, or requirements imply
+  actor workflows.
+- "Not applicable" must be represented as a waiver with reason and expiry until a stronger
+  status model is deliberately designed.
+
+## Pipeline
+
+The pipeline is:
+
+```text
+requirements
+  -> obligations
+  -> generated_e2e_candidates
+  -> selected_e2e_suite
+  -> trace_matrix
+```
+
+### 1. requirements -> obligations
+
+Inputs:
+
+- Requirements and design frontmatter.
+- `user_journeys`, runtime constraints, display fields, presentation specs, aggregation policies.
+- Lexicon expected values and browser/runtime requirements.
+- Static extraction from routes, screens, controls, forms, API handlers, role labels, and actions.
+- Existing runtime targets: connectivity, CRUD, action outcome, global action, E2E.
+- Coverage audit output and current coverage metrics.
+
+Output:
+
+- A normalized obligation matrix.
+- A blind-spot list for inferred obligations with no declaration.
+
+### 2. obligations -> generated_e2e_candidates
+
+Candidate generation modes:
+
+- Model-based paths: actor/state/action/transition graph produces role-sequence and action
+  candidates.
+- Rule/example paths: BDD or Example Mapping rules produce candidate examples.
+- Runtime target expansion: global-action, action-outcome, CRUD, and breakpoint targets produce
+  runnable candidate checks.
+- t-way expansion: role, breakpoint, auth state, data cardinality, locale/timezone, and runtime
+  target are combined to the configured strength.
+
+Candidates are not automatically selected. Each candidate must declare which obligation IDs it
+would cover.
+
+### 3. generated_e2e_candidates -> selected_e2e_suite
+
+Selection is a constrained set-cover problem:
+
+- Universe: all obligations requiring E2E coverage.
+- Candidate set: generated E2E candidates with `covers: [obligation_id...]`.
+- Objective: cover all required obligations with minimal cost, weighted by risk.
+- Constraints: test isolation, DB mutation serial rules, target runtime availability, flake risk,
+  secrets hygiene, and execution budget.
+
+### 4. selected_e2e_suite -> trace_matrix
+
+Trace matrix rows must include:
+
+- obligation ID and source.
+- selected evidence or delegated lower-level evidence.
+- current status.
+- waiver fields when relevant.
+- last verification artifact.
+- owner for uncovered or expired-waiver rows.
+
+## Candidate Selection Rules
+
+### Set Cover
+
+Choose the smallest suite that covers required E2E obligations, but do not optimize only for count.
+The cost function should include runtime, setup cost, flake risk, DB mutation risk, and maintenance
+cost.
+
+Example scoring:
+
+```text
+score(candidate) =
+  risk_weighted_new_obligations_covered
+  - runtime_cost
+  - mutation_isolation_cost
+  - flake_risk
+  - duplicate_penalty
+```
+
+### Duplicate Suppression
+
+Suppress candidates when:
+
+- Their `covers` set is a strict subset of a cheaper already selected candidate.
+- They test the same actor/goal/outcome with only route wording differences.
+- They rely on the same setup and assert no additional side effects.
+- They differ only by selector style, not behavioral evidence.
+
+Do not suppress when:
+
+- Different breakpoints change navigation availability.
+- Different roles change authorization or data visibility.
+- Different cardinalities change aggregation behavior.
+- Different runtime targets change deployment capability.
+
+### Risk-Based Depth
+
+Default depth:
+
+| Risk | Required depth |
+| --- | --- |
+| P0 | E2E required unless explicit waiver; t-way strength 3+ for relevant axes; post-deploy gate. |
+| P1 | E2E or strong lower-level delegation with at least one E2E integration path. |
+| P2 | Lower-level delegation acceptable; E2E only if cross-boundary behavior is the risk. |
+| P3 | Static/unit evidence or waiver acceptable when rationale is recorded. |
+
+### t-way Strength
+
+Default axis set:
+
+- actor / role.
+- breakpoint / viewport.
+- auth state.
+- data cardinality.
+- locale / timezone / format.
+- runtime target.
+- feature flag / organization configuration when declared.
+
+Default strength:
+
+- P0: 3-way for relevant axes, with manually pinned critical combinations.
+- P1: 2-way plus role-specific critical combinations.
+- P2/P3: pairwise only when parameter interaction is the known risk.
+
+### Lower-Level Test Delegation
+
+Use `covered_by_lower_test` when:
+
+- The risk is pure calculation, parsing, formatting, or API contract behavior.
+- Browser behavior adds little evidence.
+- A lower-level test directly references the obligation and asserts the expected outcome.
+- The trace matrix records the test reference.
+
+Do not delegate when:
+
+- Role, navigation, layout, browser session, deployment runtime, or cross-screen sequence is the
+  defect class.
+- The obligation was inferred from a prior E2E miss.
+- The lower-level test does not assert the user-visible outcome.
+
+## Undeclared Blind Spot Detection
+
+CoDD should infer blind spots before generation:
+
+| Signal | Blind spot | Required treatment |
+| --- | --- | --- |
+| Actor/role appears in requirements but no role-sequence obligation exists. | Missing role journey. | Create `uncovered` role-sequence obligation unless waived. |
+| Route/screen has visible controls but no action-outcome obligation. | Button/link may be inert. | Create action-outcome candidate. |
+| Runtime global action exists for desktop but no mobile/breakpoint declaration. | Responsive session action can disappear. | Create global-action + breakpoint obligations. |
+| Collection display has count/average/latest language but no aggregation policy. | Misleading aggregate display. | Create aggregation-policy obligation. |
+| Date/time/status display has locale-sensitive values but no presentation spec. | Raw or wrong locale display. | Create presentation-locale obligation. |
+| `--runtime-skip`, no runtime target, or no declared journey. | Silent incomplete coverage. | Mark incomplete, never green. |
+| Waiver expiry is past. | Stale exemption. | Revert to uncovered. |
+| E2E generated from route list covers no requirement/source. | Unanchored test. | Keep as candidate only, not trace evidence. |
+
+This changes the existing C7 "no user_journeys declared" skip behavior for projects that contain
+actor, route, or requirement evidence. A truly actorless project may still have no role-sequence
+obligations, but the absence must be derived, not assumed.
+
+## Domain-Neutral Example Scope
+
+The following examples use a generic multi-role web application. They are illustrative only
+and must not become hardcoded CoDD core vocabulary.
+
+### Journey Samples
+
+#### platform_admin: account and resource oversight
+
+1. Log in as platform administrator.
+2. Open admin dashboard.
+3. Open accounts.
+4. Create or edit an account.
+5. Open shared resources.
+6. Assign or inspect resource access.
+7. Confirm notification or audit evidence.
+8. Log out.
+
+#### organization_admin: member operation and progress review
+
+1. Log in as organization administrator.
+2. Open organization dashboard.
+3. Open member list.
+4. Add or inspect a member.
+5. Open assigned resources.
+6. Inspect progress with aggregation semantics.
+7. Open notifications.
+8. Log out.
+
+#### end_user: work and completion path
+
+1. Log in as end user.
+2. Open personal dashboard.
+3. Open assigned work list.
+4. Open work detail.
+5. Start or continue work.
+6. Submit progress or assessment.
+7. Open notification detail.
+8. Log out.
+
+### Obligation Matrix Example
+
+| obligation_id | kind | actor | goal | expected_outcomes | risk_level | coverage_status | covered_by | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| obl:generic:platform_admin:login_dashboard | role_sequence | platform_admin | Reach admin dashboard after login. | Dashboard visible; session established. | P0 | covered_by_e2e | tests/smoke/login-obligation-signals.spec.ts | Role-sequence start. |
+| obl:generic:platform_admin:account_create_visible | action_outcome | platform_admin | Create account and see it in list/detail. | Account row/detail visible. | P0 | uncovered | null | Example uncovered row for future CRUD E2E. |
+| obl:generic:platform_admin:access_manage | crud_flow | platform_admin | Add/edit/remove resource access. | Mutation reflected; candidate list updates. | P0 | covered_by_e2e | tests/smoke/access-management.spec.ts | CRUD flow with UI reflection. |
+| obl:generic:platform_admin:audit_signal | lower_level_contract | platform_admin | Admin mutation emits audit signal. | Audit record exists. | P1 | covered_by_lower_test | tests/api/audit-log.test.ts | Browser adds low value if UI has no audit screen. |
+| obl:generic:platform_admin:logout_mobile | global_action | platform_admin | Log out on mobile. | Logout visible; protected route redirects after logout. | P0 | covered_by_e2e | tests/smoke/mobile-logout.spec.ts | Breakpoint-critical. |
+| obl:generic:organization_admin:login_dashboard | role_sequence | organization_admin | Reach organization dashboard after login. | Organization dashboard visible. | P0 | covered_by_e2e | tests/smoke/login-obligation-signals.spec.ts | Role-sequence start. |
+| obl:generic:organization_admin:add_member | action_outcome | organization_admin | Add member and see readback. | Member appears in organization list. | P0 | covered_by_e2e | tests/smoke/nonadmin-role-matrix.spec.ts | Cross-role organization boundary. |
+| obl:generic:organization_admin:progress_aggregation | aggregation_policy | organization_admin | See progress aggregate with source count. | Average and source count match fixture. | P0 | covered_by_e2e | tests/smoke/presentation-signals.spec.ts | C7 aggregation obligation. |
+| obl:generic:organization_admin:notification_locale | presentation_locale | organization_admin | See localized notification date/time. | Locale-specific date/time; no raw ISO. | P1 | covered_by_e2e | tests/smoke/presentation-signals.spec.ts | C7 presentation obligation. |
+| obl:generic:organization_admin:logout_desktop | global_action | organization_admin | Log out on desktop. | Navigation/logout works; protected route redirects. | P0 | covered_by_e2e | tests/smoke/desktop-logout.spec.ts | Breakpoint pair with mobile. |
+| obl:generic:end_user:login_dashboard | role_sequence | end_user | Reach personal dashboard after login. | Personal dashboard visible. | P0 | covered_by_e2e | tests/smoke/login-obligation-signals.spec.ts | Role-sequence start. |
+| obl:generic:end_user:work_list | role_sequence | end_user | Open assigned work. | Assigned work list visible. | P1 | covered_by_e2e | tests/smoke/nonadmin-role-matrix.spec.ts | Sequence continuation. |
+| obl:generic:end_user:progress_action | action_outcome | end_user | Complete progress action. | Progress persists after reload. | P0 | uncovered | null | Must not be accepted from click-only evidence. |
+| obl:generic:end_user:assessment_result | action_outcome | end_user | Submit assessment and see result. | Result visible and persisted. | P1 | covered_by_lower_test | tests/api/assessment-submit.test.ts | Needs E2E only if UI path remains risky. |
+| obl:generic:end_user:notification_detail | role_sequence | end_user | Open notification detail and return to dashboard. | Detail visible; navigation escape route exists. | P1 | waived_with_reason_and_expiry | null | Example waiver: covered next iteration with expiry. |
+
+Important: the final matrix must not allow `covered_by_e2e` unless the referenced test actually
+asserts the outcome and reports zero skips.
+
+### Selected E2E Suite Example
+
+| selected_test | Covers obligations | Selection reason |
+| --- | --- | --- |
+| `tests/smoke/login-obligation-signals.spec.ts` | platform_admin login, organization_admin login, end_user login | One isolated candidate covers the start of all three role sequences and core auth runtime. |
+| `tests/smoke/presentation-signals.spec.ts` | progress aggregation, notification locale | User-visible presentation/aggregation cannot be delegated when it is the risk. |
+| `tests/smoke/mobile-logout.spec.ts` | mobile global action for all roles | Covers breakpoint-specific logout disappearance risk. |
+| `tests/smoke/desktop-logout.spec.ts` | desktop global action for all roles | Complements mobile and guards layout substitution. |
+| `tests/smoke/nonadmin-role-matrix.spec.ts` | organization add member, end-user work list | Cross-role, organization-scoped path; higher value than isolated route smoke. |
+
+Excluded or delegated examples:
+
+- Admin audit signal is delegated to a lower-level API/database test because the user-visible admin
+  outcome is already covered and the audit UI is not the risk.
+- Learner lesson progress remains uncovered in this example because click-only evidence would be
+  false confidence.
+- Notification detail has an explicit waiver with expiry; it must not count as covered after expiry.
+
+## New Concepts vs Elevated Existing Concepts
+
+New concepts:
+
+- `coverage_obligation`: explicit record of a behavior, constraint, or evidence requirement.
+- `obligation matrix`: normalized list of all obligations and their statuses.
+- `coverage_status`: four-value status model that treats skip, implicit opt-out, and expired waiver
+  as incomplete.
+- `generated_e2e_candidates`: candidate tests with declared covered obligation IDs.
+- `selected_e2e_suite`: risk-aware set-cover output, not every generated candidate.
+- `trace_matrix`: final auditable map from source to obligation to evidence/status.
+
+Elevated existing concepts:
+
+- `user_journeys` become `role_sequence` obligations.
+- `global-action`, `action-outcome`, `crud-flow`, `connectivity`, `breakpoint-coverage`, and `e2e`
+  become obligation kinds or evidence categories under one coverage model.
+- C7 presentation and aggregation checks become explicit obligations rather than special-case
+  journey violations.
+- `coverage_metrics.py` becomes an aggregation layer over obligation status.
+- `coverage_auditor.py` remains a review and classification helper, but not the canonical status.
+- `e2e_extractor.py` and `e2e_generator.py` become candidate producers, not coverage authority.
+
+## Impact Surface
+
+Requirements:
+
+- Requirements and design docs should be able to declare obligations directly or indirectly through
+  existing attributes.
+- Questions discovered by Example Mapping or BDD discovery should become uncovered or blocked
+  obligations, not disappear from the trace.
+
+Lexicon:
+
+- Expected values may carry evidence signals, browser requirements, presentation requirements, and
+  aggregation signals.
+- Lexicon should not encode project-specific route names into CoDD core.
+
+Static extraction:
+
+- Routes, screens, forms, buttons, role names, and transitions can infer candidate obligations.
+- Static inference should create `uncovered` rows when no declaration exists, not auto-accept.
+
+Runtime:
+
+- Runtime smoke categories provide evidence for obligations.
+- A skipped category is incomplete.
+- Target health/connectivity is prerequisite evidence and should not be confused with behavioral
+  coverage.
+
+Generation:
+
+- E2E generation should consume selected candidates and output tests that assert user-visible
+  outcomes with stable locators and web-first assertions.
+
+Reporting:
+
+- Coverage reports should show both percentage and blocking rows.
+- The useful gate is not "E2E generated", but "no P0/P1 obligation is uncovered, skipped, or expired".
+
+## Alternatives Considered
+
+| Alternative | Pros | Cons | Decision |
+| --- | --- | --- | --- |
+| Persona-Journey as the top-level concept | Easy to explain to humans; aligns with role workflows. | Misses action-outcome, global-action, aggregation, presentation, and lower-level delegation. | Reject as top-level; keep as role-sequence subset. |
+| Route-driven E2E generation | Simple and already close to existing extractor/generator. | Produces unanchored tests and misses obligations that are not routes. | Reject as coverage authority; keep as candidate input. |
+| Obligation-first model | Unifies existing checks, traceability, risk, selection, and waiver semantics. | Requires schema, status normalization, and selection logic. | Recommend. |
+
+## Open Questions for Review
+
+- Should `waived_with_reason_and_expiry` be the only non-covered exemption, or should a fifth
+  `not_applicable_with_reason` status exist later?
+- Should obligation IDs be generated from source paths, semantic names, or both?
+- What is the default risk policy for projects without explicit P0-P3 annotations?
+- Should selected E2E suite output be committed as a manifest, or generated during verify?
+- How strict should the first implementation be when legacy projects have many implicit opt-outs?
+
+## Acceptance for This Design Phase
+
+This design satisfies the design-phase intent when:
+
+- Coverage-Obligation Driven E2E is the main concept.
+- Persona-Journey is explicitly scoped to `role x sequence` obligations.
+- External research is cited with URLs and adaptation decisions.
+- The schema contains required fields and normalized statuses.
+- The pipeline is defined from requirements to trace matrix.
+- Candidate selection includes set cover, duplicate suppression, risk-based depth, t-way strength,
+  and lower-level test delegation.
+- Undeclared blind spots are treated as incomplete coverage.
+- Examples are domain-neutral and do not introduce project-specific vocabulary into CoDD core.

--- a/docs/design/user-journey-coherence.md
+++ b/docs/design/user-journey-coherence.md
@@ -116,6 +116,48 @@ user_journeys:
 
 `steps[].action` の語彙 (`navigate` / `form_submit` / `expect_url` / `expect_browser_state` 等) も project 自身の語彙で、CoDD core は意味解釈しない。
 
+### `design_doc.attributes.display_fields` / `presentation_specs` / `aggregation_policies`
+
+表示値の format / locale / timezone / aggregation 方針も、既存 `design_doc`
+属性として宣言する。新 node kind は追加しない。C7 は宣言がある場合だけ
+field 単位の obligation と E2E evidence signal を照合する。
+
+```yaml
+display_fields:
+  - field_id: "record.published_at"
+    data_type: "datetime"
+    lexicon_refs: ["i18n_unicode_cldr#time_zone_handling"]
+    presentation_required: true
+    expected_presentation_signals: ["record_published_at_locale_display"]
+  - field_id: "record.summary_value"
+    data_type: "number"
+    cardinality: "0..N"
+    aggregation_required: true
+    expected_aggregation_signals: ["record_summary_many_source_display"]
+
+presentation_specs:
+  - field_id: "record.published_at"
+    format: "YYYY-MM-DD HH:mm"
+    timezone: "Etc/UTC"
+    locale: "en-US"
+
+aggregation_policies:
+  - field_id: "record.summary_value"
+    cardinality_when_zero: { display: "empty_state" }
+    cardinality_when_one: { display: "raw" }
+    cardinality_when_many:
+      policy: "average"
+      source_traceability: "source_count"
+    test_data_variants:
+      required_cardinality: ["0", "1", "N"]
+```
+
+この形は variation coverage を三層に分ける。
+
+1. 要件 obligation: field が必要とする presentation / aggregation 方針を宣言する。
+2. test variant: E2E が expected signal を assert する。
+3. test data variation: seed / fixture / generated data が 0 / 1 / N などの cardinality case を持つ。
+
 ### `impl_file.attributes.runtime_evidence`
 
 `codd.yaml [coherence.capability_patterns]` で project が宣言した正規表現で impl_file をスキャンし、何の capability を「証跡として実装している」かを記録する。
@@ -260,6 +302,10 @@ for design_doc in dag.nodes(kind="design_doc"):
 | `unsatisfied_runtime_capability` | red | design_doc.runtime_constraints が要求する capability を runtime_state が提供しない (今夜事故の主検出器) |
 | `impl_evidence_runtime_mismatch` | red | impl_file の runtime_evidence (例: `__Secure-` cookie 発行) が runtime capability (例: `tls_termination=false`) と矛盾 (今夜事故の補強検出器) |
 | `browser_expected_not_asserted` | red | lexicon の `browser_requirements` が E2E test で assert されない |
+| `presentation_locale_unspecified` | red | displayed field に locale / timezone / format obligation があるが、field-level presentation spec が不足 |
+| `presentation_locale_violated` | red | presentation spec はあるが、対応する E2E evidence signal が assert されない |
+| `aggregation_policy_unspecified` | red | collection / cardinality display に aggregation policy が不足 |
+| `aggregation_policy_violated` | red | aggregation policy はあるが、対応する E2E evidence signal が assert されない |
 | `journey_step_no_assertion` | amber | journey.steps に検証 step (`expect_*`) が 1 件も含まれない |
 
 ### 出力例 (osato-lms HTTP × `__Secure-` 事故)

--- a/tests/lexicons/test_data_aggregation_policies.py
+++ b/tests/lexicons/test_data_aggregation_policies.py
@@ -1,0 +1,82 @@
+"""Coverage and loadability tests for the data_aggregation_policies lexicon plug-in."""
+
+from pathlib import Path
+
+import yaml
+
+from codd.elicit.lexicon_loader import load_lexicon
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEXICON_ROOT = REPO_ROOT / "codd_plugins" / "lexicons" / "data_aggregation_policies"
+EXPECTED_AXES = {
+    "collection_cardinality",
+    "test_data_variation",
+    "aggregation_function",
+    "empty_partial_state",
+    "grouping_dimension",
+    "recency_selection",
+    "source_traceability",
+}
+EXPECTED_KINDS = {
+    "cardinality_display_gap",
+    "test_data_variation_gap",
+    "aggregation_policy_gap",
+    "empty_partial_state_gap",
+    "grouping_dimension_gap",
+    "recency_selection_gap",
+    "source_traceability_gap",
+}
+
+
+def _yaml(name: str) -> dict:
+    return yaml.safe_load((LEXICON_ROOT / name).read_text(encoding="utf-8"))
+
+
+def test_data_aggregation_policies_loads_as_lexicon_config():
+    config = load_lexicon(LEXICON_ROOT)
+
+    assert config.lexicon_name == "data_aggregation_policies"
+    assert "Data Aggregation Policy Coverage Lexicon" in config.prompt_extension_content
+    assert set(config.recommended_kinds) == EXPECTED_KINDS
+
+
+def test_data_aggregation_policies_required_plugin_files_exist():
+    for filename in (
+        "manifest.yaml",
+        "lexicon.yaml",
+        "severity_rules.yaml",
+        "coverage_matrix.md",
+        "elicit_extend.md",
+        "recommended_kinds.yaml",
+    ):
+        assert (LEXICON_ROOT / filename).is_file()
+
+
+def test_data_aggregation_policies_axes_match_manifest_observation_dimensions():
+    manifest = _yaml("manifest.yaml")
+    axes = _yaml("lexicon.yaml")["coverage_axes"]
+
+    assert len(axes) == manifest["observation_dimensions"]
+    assert {axis["axis_type"] for axis in axes} == EXPECTED_AXES
+
+
+def test_data_aggregation_policies_axes_have_test_data_variation_obligation():
+    axes = {axis["axis_type"]: axis for axis in _yaml("lexicon.yaml")["coverage_axes"]}
+    variant_ids = {variant["id"] for variant in axes["test_data_variation"]["variants"]}
+
+    assert {"seed_zero_records", "seed_one_record", "seed_many_records"} <= variant_ids
+
+
+def test_data_aggregation_policies_severity_rules_cover_each_axis_gap():
+    axes = {axis["axis_type"] for axis in _yaml("lexicon.yaml")["coverage_axes"]}
+    rules = _yaml("severity_rules.yaml")["rules"]
+    rule_conditions = {rule["when"] for rule in rules}
+
+    for axis in axes:
+        assert f"axis={axis} AND coverage=gap" in rule_conditions
+
+    severity_by_condition = {rule["when"]: rule["severity"] for rule in rules}
+    assert severity_by_condition["axis=collection_cardinality AND coverage=gap"] == "high"
+    assert severity_by_condition["axis=test_data_variation AND coverage=gap"] == "high"
+    assert severity_by_condition["axis=empty_partial_state AND coverage=gap"] == "medium"

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -817,6 +817,97 @@ runtime:
     assert "runtime.global_action_targets" not in result.output
 
 
+def test_t48_doctor_warns_on_missing_presentation_obligation(tmp_path):
+    project = _project(tmp_path)
+    docs = project / "docs" / "design"
+    docs.mkdir(parents=True)
+    (docs / "presentation.md").write_text(
+        """
+---
+display_fields:
+  - field_id: record.published_at
+    data_type: datetime
+    lexicon_refs: ["i18n_unicode_cldr#time_zone_handling"]
+    presentation_required: true
+---
+# Presentation
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(main, ["doctor", "--path", str(project)])
+
+    assert result.exit_code == 0
+    assert "CoDD doctor: WARN" in result.output
+    assert "W-PRES-001" in result.output
+    assert "W-PRES-002" in result.output
+    assert "displayed field `record.published_at`" in result.output
+
+
+def test_t49_doctor_warns_on_missing_aggregation_policy(tmp_path):
+    project = _project(tmp_path)
+    docs = project / "docs" / "design"
+    docs.mkdir(parents=True)
+    (docs / "presentation.md").write_text(
+        """
+---
+display_fields:
+  - field_id: record.summary_value
+    cardinality: "0..N"
+    aggregation_required: true
+---
+# Presentation
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(main, ["doctor", "--path", str(project)])
+
+    assert result.exit_code == 0
+    assert "CoDD doctor: WARN" in result.output
+    assert "W-AGG-001" in result.output
+    assert "collection/cardinality display field `record.summary_value`" in result.output
+
+
+def test_t50_doctor_accepts_declared_presentation_and_aggregation_obligations(tmp_path):
+    project = _project(tmp_path)
+    docs = project / "docs" / "design"
+    docs.mkdir(parents=True)
+    (docs / "presentation.md").write_text(
+        """
+---
+display_fields:
+  - field_id: record.published_at
+    data_type: datetime
+    lexicon_refs: ["i18n_unicode_cldr#time_zone_handling"]
+    presentation_required: true
+  - field_id: record.summary_value
+    cardinality: "0..N"
+    aggregation_required: true
+presentation_specs:
+  - field_id: record.published_at
+    format: "YYYY-MM-DD HH:mm"
+    timezone: "Etc/UTC"
+    locale: "en-US"
+aggregation_policies:
+  - field_id: record.summary_value
+    cardinality_when_many:
+      policy: average
+    test_data_variants:
+      required_cardinality: ["0", "1", "N"]
+---
+# Presentation
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(main, ["doctor", "--path", str(project)])
+
+    assert result.exit_code == 0
+    assert "W-PRES" not in result.output
+    assert "W-AGG" not in result.output
+
+
 def test_t24_doctor_warns_on_post_without_reflection_e2e(tmp_path):
     project = _project(tmp_path)
     source_dir = project / "src"

--- a/tests/test_user_journey_c7_check.py
+++ b/tests/test_user_journey_c7_check.py
@@ -33,6 +33,9 @@ def _dag(
     *,
     journey: dict | None = None,
     constraints: list[dict] | None = None,
+    display_fields: list[dict] | None = None,
+    presentation_specs: list[dict] | None = None,
+    aggregation_policies: list[dict] | None = None,
     expected: bool = True,
     expected_attrs: dict | None = None,
     plan_outputs: list[str] | None = None,
@@ -51,6 +54,9 @@ def _dag(
             attributes={
                 "runtime_constraints": constraints or [],
                 "user_journeys": [journey or _journey()],
+                "display_fields": display_fields or [],
+                "presentation_specs": presentation_specs or [],
+                "aggregation_policies": aggregation_policies or [],
             },
         )
     )
@@ -408,6 +414,159 @@ def test_browser_expected_asserted_by_e2e_attributes_passes(tmp_path):
     )
 
     assert "browser_expected_not_asserted" not in _types(result)
+
+
+def test_presentation_locale_unspecified_is_red_for_display_field_without_spec(tmp_path):
+    result = _run(
+        _dag(
+            plan_outputs=["lexicon:e2e_login_journey"],
+            display_fields=[
+                {
+                    "field_id": "record.published_at",
+                    "data_type": "datetime",
+                    "lexicon_refs": ["i18n_unicode_cldr#time_zone_handling"],
+                    "presentation_required": True,
+                }
+            ],
+        ),
+        tmp_path,
+    )
+
+    violation = _violation(result, "presentation_locale_unspecified")
+    assert result.passed is False
+    assert violation["field_id"] == "record.published_at"
+    assert violation["missing_attributes"] == ["presentation_spec"]
+
+
+def test_presentation_locale_violated_is_red_when_evidence_signal_is_unasserted(tmp_path):
+    result = _run(
+        _dag(
+            plan_outputs=["lexicon:e2e_login_journey"],
+            display_fields=[
+                {
+                    "field_id": "record.published_at",
+                    "data_type": "datetime",
+                    "expected_presentation_signals": ["record_published_at_locale_display"],
+                }
+            ],
+            presentation_specs=[
+                {
+                    "field_id": "record.published_at",
+                    "format": "YYYY-MM-DD HH:mm",
+                    "timezone": "Etc/UTC",
+                    "locale": "en-US",
+                }
+            ],
+        ),
+        tmp_path,
+    )
+
+    violation = _violation(result, "presentation_locale_violated")
+    assert result.passed is False
+    assert violation["missing_evidence_signals"] == ["record_published_at_locale_display"]
+
+
+def test_presentation_locale_signal_assertion_passes(tmp_path):
+    result = _run(
+        _dag(
+            plan_outputs=["lexicon:e2e_login_journey"],
+            display_fields=[
+                {
+                    "field_id": "record.published_at",
+                    "data_type": "datetime",
+                    "expected_presentation_signals": ["record_published_at_locale_display"],
+                }
+            ],
+            presentation_specs=[
+                {
+                    "field_id": "record.published_at",
+                    "format": "YYYY-MM-DD HH:mm",
+                    "timezone": "Etc/UTC",
+                    "locale": "en-US",
+                }
+            ],
+            e2e_attrs={"assertions": ["record_published_at_locale_display"]},
+        ),
+        tmp_path,
+    )
+
+    assert "presentation_locale_unspecified" not in _types(result)
+    assert "presentation_locale_violated" not in _types(result)
+
+
+def test_aggregation_policy_unspecified_is_red_for_many_source_display(tmp_path):
+    result = _run(
+        _dag(
+            plan_outputs=["lexicon:e2e_login_journey"],
+            display_fields=[
+                {
+                    "field_id": "record.summary_value",
+                    "cardinality": "0..N",
+                    "aggregation_required": True,
+                }
+            ],
+        ),
+        tmp_path,
+    )
+
+    violation = _violation(result, "aggregation_policy_unspecified")
+    assert result.passed is False
+    assert violation["field_id"] == "record.summary_value"
+    assert violation["cardinality"] == "0..N"
+
+
+def test_aggregation_policy_violated_is_red_when_evidence_signal_is_unasserted(tmp_path):
+    result = _run(
+        _dag(
+            plan_outputs=["lexicon:e2e_login_journey"],
+            display_fields=[
+                {
+                    "field_id": "record.summary_value",
+                    "cardinality": "0..N",
+                    "expected_aggregation_signals": ["record_summary_many_source_display"],
+                }
+            ],
+            aggregation_policies=[
+                {
+                    "field_id": "record.summary_value",
+                    "cardinality_when_many": {"policy": "average"},
+                    "test_data_variants": {"required_cardinality": ["0", "1", "N"]},
+                }
+            ],
+        ),
+        tmp_path,
+    )
+
+    violation = _violation(result, "aggregation_policy_violated")
+    assert result.passed is False
+    assert violation["missing_evidence_signals"] == ["record_summary_many_source_display"]
+
+
+def test_aggregation_policy_signal_assertion_passes(tmp_path):
+    result = _run(
+        _dag(
+            plan_outputs=["lexicon:e2e_login_journey"],
+            display_fields=[
+                {
+                    "field_id": "record.summary_value",
+                    "cardinality": "0..N",
+                    "expected_aggregation_signals": ["record_summary_many_source_display"],
+                }
+            ],
+            aggregation_policies=[
+                {
+                    "field_id": "record.summary_value",
+                    "cardinality_when_many": {"policy": "average"},
+                    "test_data_variants": {"required_cardinality": ["0", "1", "N"]},
+                }
+            ],
+            e2e_attrs={"assertions": ["record_summary_many_source_display"]},
+        ),
+        tmp_path,
+    )
+
+    assert "aggregation_policy_unspecified" not in _types(result)
+    assert "aggregation_policy_violated" not in _types(result)
 
 
 def test_journey_step_no_assertion_is_amber_and_does_not_fail(tmp_path):

--- a/tests/test_user_journey_design_doc_attrs.py
+++ b/tests/test_user_journey_design_doc_attrs.py
@@ -194,6 +194,47 @@ def test_required_capabilities_are_preserved_on_design_doc_attributes(tmp_path):
     assert attributes["user_journeys"][0]["required_capabilities"] == ["tls_termination", "cookie_store"]
 
 
+def test_display_presentation_and_aggregation_attrs_are_preserved(tmp_path):
+    frontmatter = {
+        "user_journeys": [_journey(expected_outcome_refs=[])],
+        "display_fields": [
+            {
+                "field_id": "record.summary_value",
+                "cardinality": "0..N",
+                "expected_aggregation_signals": ["record_summary_many_source_display"],
+            }
+        ],
+        "presentation_specs": [
+            {
+                "field_id": "record.published_at",
+                "format": "YYYY-MM-DD HH:mm",
+                "timezone": "Etc/UTC",
+                "locale": "en-US",
+            }
+        ],
+        "aggregation_policies": [
+            {
+                "field_id": "record.summary_value",
+                "cardinality_when_many": {"policy": "average"},
+                "test_data_variants": {"required_cardinality": ["0", "1", "N"]},
+            }
+        ],
+    }
+    _write(tmp_path / "docs" / "design" / "auth.md", _doc_with_frontmatter(frontmatter))
+    dag = build_dag(tmp_path, _settings())
+
+    attributes = dag.nodes["docs/design/auth.md"].attributes
+
+    assert attributes["display_fields"][0]["field_id"] == "record.summary_value"
+    assert attributes["display_fields"][0]["expected_aggregation_signals"] == ["record_summary_many_source_display"]
+    assert attributes["display_fields"][0]["lexicon_refs"] == []
+    assert attributes["display_fields"][0]["evidence_signals"] == []
+    assert attributes["presentation_specs"][0]["format"] == "YYYY-MM-DD HH:mm"
+    assert attributes["presentation_specs"][0]["expected_presentation_signals"] == []
+    assert attributes["aggregation_policies"][0]["cardinality_when_many"] == {"policy": "average"}
+    assert attributes["aggregation_policies"][0]["test_data_variants"] == {"required_cardinality": ["0", "1", "N"]}
+
+
 def test_existing_design_doc_frontmatter_free_regression(tmp_path):
     _write(tmp_path / "docs" / "design" / "api.md", "# API\nBody\n")
 


### PR DESCRIPTION
## Summary

This PR generalizes the LMS display/aggregation blind spots into CoDD core.

- Add `display_fields`, `presentation_specs`, and `aggregation_policies` as design document attributes.
- Extend C7 `user_journey_coherence` with presentation and aggregation obligation violations.
- Add `codd doctor` warnings for missing presentation specs and aggregation policies.
- Add the `data_aggregation_policies` lexicon and stack-map hook.
- Add cookbook guidance for presentation/aggregation obligations.
- Add the proposed Coverage-Obligation Driven E2E design with domain-neutral examples.

## Why

Real product screens can be green on route/login smoke tests while still showing wrong datetime locale/timezone or misleading many-to-one aggregate values. CoDD needs field-level declarations and E2E evidence signals so these display semantics are not treated as incidental UI details.

## Validation

- `.venv/bin/python -m pytest tests/test_runtime_smoke.py tests/test_user_journey_c7_check.py tests/test_user_journey_design_doc_attrs.py tests/lexicons/test_data_aggregation_policies.py -q` -> 104 passed

## Excluded

- `.codd/dag.json` generated output
- `docs/swebench/v2.11.0_run.md` benchmark note unrelated to this CoDD feature