### PR TITLE
fix(packaging): bundle built-in lexicons in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,3 +89,4 @@ packages = ["codd"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "skills" = "codd/_skills"
+"codd_plugins" = "codd_plugins"

--- a/tests/test_project_wheel_bundles_lexicons.py
+++ b/tests/test_project_wheel_bundles_lexicons.py
@@ -1,0 +1,62 @@
+"""Regression coverage for built-wheel lexicon payloads."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import zipfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_ROOT = REPO_ROOT / "codd_plugins"
+LEXICON_ROOT = PLUGIN_ROOT / "lexicons"
+
+
+def _relative_paths(paths: list[Path]) -> set[str]:
+    return {path.relative_to(REPO_ROOT).as_posix() for path in paths}
+
+
+def test_built_wheel_bundles_every_builtin_lexicon_file(tmp_path: Path) -> None:
+    """The distributable wheel must retain the top-level plug-in data tree."""
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            "--no-deps",
+            "--no-build-isolation",
+            "--wheel-dir",
+            str(tmp_path),
+            str(REPO_ROOT),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+
+    source_manifests = _relative_paths(sorted(LEXICON_ROOT.rglob("manifest.yaml")))
+    api_rest_openapi_files = _relative_paths(
+        sorted(path for path in (LEXICON_ROOT / "api_rest_openapi").rglob("*") if path.is_file())
+    )
+    stack_map = "codd_plugins/stack_map.yaml"
+
+    assert len(source_manifests) == 39
+    assert len(api_rest_openapi_files) == 6
+    assert f"codd_plugins/lexicons/api_rest_openapi/manifest.yaml" in source_manifests
+    assert (REPO_ROOT / stack_map).is_file()
+
+    wheels = list(tmp_path.glob("codd_dev-3.37.0-*.whl"))
+    assert len(wheels) == 1
+    with zipfile.ZipFile(wheels[0]) as wheel:
+        wheel_files = set(wheel.namelist())
+
+    wheel_manifests = {
+        path
+        for path in wheel_files
+        if path.startswith("codd_plugins/lexicons/") and path.endswith("/manifest.yaml")
+    }
+    assert wheel_manifests == source_manifests
+    assert len(wheel_manifests) == 39
+    assert api_rest_openapi_files <= wheel_files
+    assert stack_map in wheel_files


### PR DESCRIPTION
## Summary

The PyPI codd-dev 3.37.0 wheel contains 0 codd_plugins files, while the matching source/sdist contains 39 lexicon manifests. This leaves a clean installation with `codd lexicon list` reporting Installed 0 / Available 0, and a coverage check using api_rest_openapi fails with Unknown lexicon (exit 2).

The cause is that the wheel target selects only packages=["codd"], so the top-level codd_plugins data tree is omitted. This PR adds one Hatch force-include mapping for codd_plugins and an artifact-level regression test.

## Verification

- The regression test builds the real wheel and compares the complete source and archive manifest-path sets (39 manifests), not just a count.
- It also asserts all 6 api_rest_openapi files and codd_plugins/stack_map.yaml are in the archive.
- A clean venv, installed from the built wheel with --force-reinstall --no-deps, reports Available 39 and includes api_rest_openapi when run outside the clone with PYTHONPATH empty and Python isolated mode.
- line_harness codd coverage check completes with exit 0 and no Unknown lexicon.
- Task unit/build/coverage checks have 0 skips.

## Scope

This changes no runtime API, LexiconManager behavior, lexicon schema, coverage threshold, or version. The fork artifact is pinned only for internal recovery; this PR does not publish to PyPI. Merge, release, versioning, and publication timing remain entirely at the upstream maintainer’s discretion.